### PR TITLE
Disable proxy cache and gzip

### DIFF
--- a/app/nginx/prod.conf
+++ b/app/nginx/prod.conf
@@ -21,25 +21,24 @@ http {
     access_log  /var/log/nginx/access.log  main;
 
     sendfile        on;
-    sendfile_max_chunk 512k;
     keepalive_timeout  65;
     include /etc/nginx/conf.d/*.conf;
 
-    proxy_cache_path /var/cache/nginx keys_zone=PROXYCACHE:100m inactive=60m max_size=500m;
-    proxy_cache_key  "$scheme$request_method$host$request_uri";
-    add_header X-Cache-Status $upstream_cache_status;
-    proxy_cache_min_uses 0;
-    proxy_cache_revalidate on;
-    proxy_cache_use_stale error timeout updating http_500;
-    proxy_cache_background_update on;
-    proxy_cache_lock on;
+    #proxy_cache_path /var/cache/nginx keys_zone=PROXYCACHE:100m inactive=60m max_size=500m;
+    #proxy_cache_key  "$scheme$request_method$host$request_uri";
+    #add_header X-Cache-Status $upstream_cache_status;
+    #proxy_cache_min_uses 0;
+    #proxy_cache_revalidate on;
+    #proxy_cache_use_stale error timeout updating http_500;
+    #proxy_cache_background_update on;
+    #proxy_cache_lock on;
 
     server {
         listen 80 default;
         server_name default;
         
 
-        gzip on;
+        gzip off;
         gzip_min_length     256;
         gzip_proxied        any;
 
@@ -67,9 +66,9 @@ http {
 
         location /_content/ {
             rewrite ^/_content/(.*)$ /$1 break;
-            proxy_cache        PROXYCACHE;
-            proxy_cache_valid 200 302 10m;
-            proxy_cache_valid 404      1m;
+            #proxy_cache        PROXYCACHE;
+            #proxy_cache_valid 200 302 10m;
+            #proxy_cache_valid 404      1m;
             root /processed/;
         }
         
@@ -80,9 +79,9 @@ http {
         }
 
         location / {
-            proxy_cache        PROXYCACHE;
-            proxy_cache_valid 200 302 10m;
-            proxy_cache_valid 404      1m;
+            #proxy_cache        PROXYCACHE;
+            #proxy_cache_valid 200 302 10m;
+            #proxy_cache_valid 404      1m;
             root /app/build;
             index  index.html;
         }


### PR DESCRIPTION
This seems to mostly solve the streaming of large files at least when tested in Chrome. Firefox is still very flaky unfortunately so that's likely an issue with the browser and not something we'll be able to fix. 

This is likely temporary until we have nailed down what exactly is causing the issue with serving larger files. 