### PR TITLE
Remember Sort option

### DIFF
--- a/app/client/src/views/Dashboard.js
+++ b/app/client/src/views/Dashboard.js
@@ -25,7 +25,9 @@ const Dashboard = ({ authenticated, searchText, cardSize, listStyle }) => {
   const [selectedFolder, setSelectedFolder] = React.useState(
     getSetting('folder') || { value: 'All Videos', label: 'All Videos' },
   )
-  const [selectedSort, setSelectedSort] = React.useState(SORT_OPTIONS[0])
+  const [selectedSort, setSelectedSort] = React.useState(
+    getSetting('sortOption') || SORT_OPTIONS[0],
+  )
 
   const [alert, setAlert] = React.useState({ open: false })
 
@@ -82,7 +84,12 @@ const Dashboard = ({ authenticated, searchText, cardSize, listStyle }) => {
     setSetting('folder', folder)
     setSelectedFolder(folder)
   }
-
+  
+  const handleSortSelection = (sortOption) => {
+    setSetting('sortOption', sortOption)
+    setSelectedSort(sortOption)
+  }
+  
   return (
     <>
       <SnackbarAlert severity={alert.type} open={alert.open} setOpen={(open) => setAlert({ ...alert, open })}>
@@ -107,7 +114,7 @@ const Dashboard = ({ authenticated, searchText, cardSize, listStyle }) => {
                   <Select
                     value={selectedSort}
                     options={SORT_OPTIONS}
-                    onChange={(option) => setSelectedSort(option)}
+                    onChange={handleSortSelection}
                     styles={selectSortTheme}
                     blurInputOnSelect
                     isSearchable={false}

--- a/app/client/src/views/Feed.js
+++ b/app/client/src/views/Feed.js
@@ -38,7 +38,9 @@ const Feed = ({ authenticated, searchText, cardSize, listStyle }) => {
       ? { value: category, label: category }
       : getSetting('folder') || { value: 'All Videos', label: 'All Videos' },
   )
-  const [selectedSort, setSelectedSort] = React.useState(SORT_OPTIONS[0])
+  const [selectedSort, setSelectedSort] = React.useState(
+    getSetting('sortOption') || SORT_OPTIONS[0],
+  )
 
   const [alert, setAlert] = React.useState({ open: false })
 
@@ -100,7 +102,12 @@ const Feed = ({ authenticated, searchText, cardSize, listStyle }) => {
       window.history.replaceState({ category: folder.value }, '', `/#/feed?${searchParams.toString()}`)
     }
   }
-
+  
+  const handleSortSelection = (sortOption) => {
+    setSetting('sortOption', sortOption)
+    setSelectedSort(sortOption)
+  }
+  
   return (
     <>
       <SnackbarAlert severity={alert.type} open={alert.open} setOpen={(open) => setAlert({ ...alert, open })}>
@@ -126,7 +133,7 @@ const Feed = ({ authenticated, searchText, cardSize, listStyle }) => {
                     <Select
                       value={selectedSort}
                       options={SORT_OPTIONS}
-                      onChange={(option) => setSelectedSort(option)}
+                      onChange={handleSortSelection}
                       styles={selectSortTheme}
                       blurInputOnSelect
                       isSearchable={false}


### PR DESCRIPTION
Please review these commits which aims to set/get a new "sortOption" setting to remember the selected sort option when changing between the Dashboard and Feed.