### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,26 +5,26 @@ COPY app/client/package.json ./
 COPY app/client/package-lock.json ./
 COPY app/client/.env ./
 RUN npm ci --silent
-RUN npm install react-scripts@5.0.1 -g --silent
+RUN npm install react-scripts@5.0.1 -g --silent && npm cache clean --force;
 COPY app/client/ ./
 RUN npm run build
 
 FROM python:3.9-slim-buster
 WORKDIR /
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     nginx nginx-extras supervisor build-essential gcc \
     libc-dev libffi-dev python3-pip ffmpeg python-dev \
-    libldap2-dev libsasl2-dev libssl-dev
+    libldap2-dev libsasl2-dev libssl-dev && rm -rf /var/lib/apt/lists/*;
 RUN adduser --disabled-password --gecos '' nginx
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
-    && ln -sf /dev/stderr /var/log/nginx/error.log 
+    && ln -sf /dev/stderr /var/log/nginx/error.log
 RUN mkdir /data && mkdir /processed
 COPY entrypoint.sh /
 COPY app/nginx/prod.conf /etc/nginx/nginx.conf
 COPY app/server/ /app/server
 COPY migrations/ /migrations
 COPY --from=client /app/build /app/build
-RUN pip install /app/server
+RUN pip install --no-cache-dir /app/server
 
 ENV FLASK_APP /app/server/fireshare:create_app()
 ENV FLASK_ENV production


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.
* I added `rm -rf /var/lib/apt/lists/*` after `apt-get install` which removes unnecessary files and reduces the size of the image.


Impact on the image size:
* Image size before repair: 879.21 MB
* Image size after repair: 720.49 MB
* Difference: 158.71 MB (18.05%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,