### PR TITLE
fix upload card on first load

### DIFF
--- a/app/client/src/components/admin/UploadCard.js
+++ b/app/client/src/components/admin/UploadCard.js
@@ -9,7 +9,6 @@ const Input = styled('input')({
   display: 'none',
 })
 
-const uiConfig = getSetting('ui_config')
 const numberFormat = new Intl.NumberFormat('en-US')
 
 const UploadCard = ({ authenticated, feedView = false, publicUpload = false, cardWidth, handleAlert }) => {
@@ -18,6 +17,8 @@ const UploadCard = ({ authenticated, feedView = false, publicUpload = false, car
   const [isSelected, setIsSelected] = React.useState(false)
   const [progress, setProgress] = React.useState(0)
   const [uploadRate, setUploadRate] = React.useState()
+
+  const uiConfig = getSetting('ui_config')
 
   const changeHandler = (event) => {
     setProgress(0)


### PR DESCRIPTION
Band-aid fix for #189. I think the issue stems from trying to access `ui_config` before it has been set. By moving `getSetting('ui_config')` into the component, it has more chances to get `ui_config` after it has been set. Still not a perfect solution since there is still a race condition here, but the upload card has shown up on the first time for me every time now. 

A better solution would be to have a context that manages all the config options so the pages auto re-render once the config options have been fetched from the backend.