### PR TITLE
Fallback to v1.2.9. Added some handling to stand inplace of the manual file corruption check.

### DIFF
--- a/app/server/requirements.txt
+++ b/app/server/requirements.txt
@@ -21,4 +21,3 @@ zipp==3.8.0
 xxhash==3.0.0
 apscheduler==3.9.1
 python-ldap==3.4.3
-integv==1.3.0


### PR DESCRIPTION
After some more debugging, it looked best to fall back to v1.2.9 and add a try/except statement on the original line of code that was causing the errors in #191 

The manual check with integv only caused issues in prod after the Dockerfile was built. So this should avoid it entirely.
(Shane, I thank you immensely for putting up with this tom-fuckery of an idea)