### PR TITLE
Update greenlet version for Python 3.11+ support

### DIFF
--- a/app/server/requirements.txt
+++ b/app/server/requirements.txt
@@ -7,7 +7,7 @@ Flask-Migrate==3.1.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==1.0.1
 future==0.18.2
-greenlet==1.1.2
+greenlet==3.0.3
 gunicorn==20.1.0
 importlib-metadata==4.11.3
 itsdangerous==2.1.2


### PR DESCRIPTION
The current version of greenlet (1.1.2) doesn't support Python 11+. This change adds support for this, no breaking changes as far as I can see and works fine - https://github.com/python-greenlet/greenlet/blob/master/CHANGES.rst