### PR TITLE
Add support for 127.0.0.1 alongside localhost when getting relative URLs

### DIFF
--- a/app/client/src/common/utils.js
+++ b/app/client/src/common/utils.js
@@ -1,15 +1,16 @@
 import React from 'react'
 
+let isLocalhost = (window.location.hostname.indexOf('localhost') >= 0 || window.location.hostname.indexOf('127.0.0.1') >= 0) && window.location.port !== '';
 export const getServedBy = () => {
-  return (window.location.hostname.indexOf('localhost') >= 0 && window.location.port !== '')
+  return isLocalhost
     ? 'flask'
     : 'nginx'
 }
 
 export const getUrl = () => {
   const portWithColon = window.location.port ? `:${window.location.port}` : ''
-  return (window.location.hostname.indexOf('localhost') >= 0 && window.location.port !== '')
-    ? `http://localhost:${process.env.REACT_APP_SERVER_PORT || window.location.port}`
+  return isLocalhost
+    ? `http://${window.location.hostname}:${process.env.REACT_APP_SERVER_PORT || window.location.port}`
     : `${window.location.protocol}//${window.location.hostname}${portWithColon}`
 }
 
@@ -19,8 +20,8 @@ export const getPublicWatchUrl = () => {
     return `${shareableLinkDomain}/w/`
   }
   const portWithColon = window.location.port ? `:${window.location.port}` : ''
-  return (window.location.hostname.indexOf('localhost') >= 0 && window.location.port !== '')
-    ? `http://localhost:${process.env.REACT_APP_SERVER_PORT || window.location.port}/#/w/`
+  return isLocalhost
+    ? `http://${window.location.hostname}:${process.env.REACT_APP_SERVER_PORT || window.location.port}/#/w/`
     : `${window.location.protocol}//${window.location.hostname}${portWithColon}/w/`
 }
 


### PR DESCRIPTION
Currently, fireshare handles localhost specially, allowing for local development, however, 127.0.0.1 is not included in this.

This PR adds a isLocalhost variable allowing both 127.0.0.1 and localhost to make use of this functionality. I could use localhost but macOS seems to have some issues with that.

I'm also adding HLS support in #249 