### PR TITLE
Add HLS support

### DIFF
--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactPlayer from 'react-player'
 import { Button, ButtonGroup, Grid, IconButton, InputAdornment, Modal, Paper, Slide, TextField } from '@mui/material'
 import LinkIcon from '@mui/icons-material/Link'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
@@ -128,7 +129,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   }
 
   const copyTimestamp = () => {
-    copyToClipboard(`${PURL}${vid.video_id}?t=${playerRef.current?.currentTime}`)
+    copyToClipboard(`${PURL}${vid.video_id}?t=${playerRef.current?.getCurrentTime()}`)
     setAlert({
       type: 'info',
       message: 'Time stamped link copied to clipboard',
@@ -141,7 +142,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
       if (!vid.info?.duration || vid.info?.duration < 10) {
         setViewAdded(true)
         VideoService.addView(vid?.video_id || videoId).catch((err) => console.error(err))
-      } else if (e.target.currentTime >= 10) {
+      } else if (e.playedSeconds >= 10) {
         setViewAdded(true)
         VideoService.addView(vid?.video_id || videoId).catch((err) => console.error(err))
       }
@@ -180,18 +181,19 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
             </IconButton>
             <Grid container justifyContent="center">
               <Grid item xs={12}>
-                <video
+                <ReactPlayer
                   ref={playerRef}
                   width="100%"
                   height="auto"
-                  src={`${
+                  url={`${
                     SERVED_BY === 'nginx'
                       ? `${URL}/_content/video/${getVideoPath(vid.video_id, vid.extension)}`
-                      : `${URL}/api/video?id=${vid.extension === '.mkv' ? `${vid.video_id}&subid=1` : vid.video_id}`
+                      : `${URL}/api/video/stream/${vid.video_id}/stream.m3u8`
                   }`}
-                  disablePictureInPicture
+                  pip={false}
                   controls
-                  onTimeUpdate={handleTimeUpdate}
+                  playing
+                  onProgress={handleTimeUpdate}
                 />
               </Grid>
               <Grid item>

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -188,7 +188,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                   url={`${
                     SERVED_BY === 'nginx'
                       ? `${URL}/_content/video/${getVideoPath(vid.video_id, vid.extension)}`
-                      : `${URL}/api/video/stream/${vid.video_id}/stream.m3u8`
+                      : `${URL}/api/video/stream/${vid.video_id}/video.m3u8`
                   }`}
                   pip={false}
                   controls

--- a/app/client/src/views/Settings.js
+++ b/app/client/src/views/Settings.js
@@ -194,6 +194,20 @@ const Settings = ({ authenticated }) => {
                   }
                   label="Show Public Upload Card"
                 />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={updatedConfig.ui_config?.use_hls_by_default || false}
+                      onChange={(e) =>
+                        setUpdatedConfig((prev) => ({
+                          ...prev,
+                          ui_config: { ...prev.ui_config, use_hls_by_default: e.target.checked },
+                        }))
+                      }
+                    />
+                  }
+                  label="Use HLS stream by default"
+                />
                 <TextField
                   size="small"
                   label="Shareable Link Domain"

--- a/app/client/src/views/Watch.js
+++ b/app/client/src/views/Watch.js
@@ -165,7 +165,7 @@ const Watch = ({ authenticated }) => {
           value={
             SERVED_BY === 'nginx'
               ? `${URL}/_content/video/${id}${details?.extension || '.mp4'}`
-              : `${URL}/api/video?id=${id}`
+              : `${URL}/api/video/stream/${id}/stream.m3u8`
           }
         />
         <meta property="og:video:width" value={details?.info?.width} />
@@ -179,7 +179,7 @@ const Watch = ({ authenticated }) => {
             url={`${
               SERVED_BY === 'nginx'
                 ? `${URL}/_content/video/${getVideoPath(id, details?.extension || '.mp4')}`
-                : `${URL}/api/video?id=${details?.extension === '.mkv' ? `${id}&subid=1` : id}`
+                : `${URL}/api/video/stream/${id}/stream.m3u8`
             }`}
             width="100%"
             height="auto"

--- a/app/client/src/views/Watch.js
+++ b/app/client/src/views/Watch.js
@@ -165,7 +165,7 @@ const Watch = ({ authenticated }) => {
           value={
             SERVED_BY === 'nginx'
               ? `${URL}/_content/video/${id}${details?.extension || '.mp4'}`
-              : `${URL}/api/video/stream/${id}/stream.m3u8`
+              : `${URL}/api/video/stream/${id}/video.m3u8`
           }
         />
         <meta property="og:video:width" value={details?.info?.width} />
@@ -179,7 +179,7 @@ const Watch = ({ authenticated }) => {
             url={`${
               SERVED_BY === 'nginx'
                 ? `${URL}/_content/video/${getVideoPath(id, details?.extension || '.mp4')}`
-                : `${URL}/api/video/stream/${id}/stream.m3u8`
+                : `${URL}/api/video/stream/${id}/video.m3u8`
             }`}
             width="100%"
             height="auto"

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -195,9 +195,18 @@ def scan_video(ctx, path):
                         util.create_poster(video_path, derived_path / "poster.jpg", poster_time)
                     else:
                         logger.debug(f"Skipping creation of poster for video {info.video_id} because it exists at {str(poster_path)}")
+
+                    m3u8_path = Path(derived_path, "video.m3u8")
+                    should_convert_to_m3u8 = (not m3u8_path.exists() or regenerate)
+                    if should_convert_to_m3u8:
+                        if not derived_path.exists():
+                            derived_path.mkdir(parents=True)
+                        util.convert_video_to_m3u8(video_path, derived_path / "video.m3u8")
+                    else:
+                        logger.debug(f"Skipping conversion of video to m3u8 for video {info.video_id} because it exists at {str(m3u8_path)}")
                     db.session.commit()
                 else:
-                    logger.warn(f"Skipping creation of poster for video {info.video_id} because the video at {str(video_path)} does not exist or is not accessible")
+                    logger.warn(f"Skipping creation of poster and/or conversion to M3U8 for video {info.video_id} because the video at {str(m3u8_path)} already exists not exist or is not accessible")
         else:
             logger.info(f"Invalid video file, unable to scan: {str(videos_path / path)}")
 
@@ -331,6 +340,15 @@ def create_posters(regenerate, skip):
                 util.create_poster(video_path, derived_path / "poster.jpg", poster_time)
             else:
                 logger.debug(f"Skipping creation of poster for video {vi.video_id} because it exists at {str(poster_path)}")
+            
+            m3u8_path = Path(derived_path, "video.m3u8")
+            should_convert_to_m3u8 = (not m3u8_path.exists() or regenerate)
+            if should_convert_to_m3u8:
+                if not derived_path.exists():
+                    derived_path.mkdir(parents=True)
+                util.convert_video_to_m3u8(video_path, derived_path / "video.m3u8")
+            else:
+                logger.debug(f"Skipping conversion of video to m3u8 for video {vi.video_id} because it exists at {str(m3u8_path)}")
 
 @cli.command()
 @click.option("--regenerate", "-r", help="Overwrite existing posters", is_flag=True)
@@ -352,6 +370,15 @@ def create_boomerang_posters(regenerate):
                 util.create_boomerang_preview(video_path, poster_path)
             else:
                 logger.info(f"Skipping creation of boomerang poster for video {vi.video_id} because it exists at {str(poster_path)}")
+
+            m3u8_path = Path(derived_path, "video.m3u8")
+            should_convert_to_m3u8 = (not m3u8_path.exists() or regenerate)
+            if should_convert_to_m3u8:
+                if not derived_path.exists():
+                    derived_path.mkdir(parents=True)
+                util.convert_video_to_m3u8(video_path, derived_path / "video.m3u8")
+            else:
+                logger.debug(f"Skipping conversion of video to m3u8 for video {vi.video_id} because it exists at {str(m3u8_path)}")
 
 @cli.command()
 @click.pass_context

--- a/app/server/fireshare/constants.py
+++ b/app/server/fireshare/constants.py
@@ -5,12 +5,13 @@ DEFAULT_CONFIG = {
     },
     "allow_public_upload": False,
     "public_upload_folder_name": "public uploads",
-    "admin_upload_folder_name": "uploads"
+    "admin_upload_folder_name": "uploads",
   },
   "ui_config": {
     "shareable_link_domain": "",
     "show_public_upload": False,
     "show_admin_upload": True,
+    "use_hls_by_default": False,
   }
 }
 

--- a/app/server/fireshare/templates/metadata.html
+++ b/app/server/fireshare/templates/metadata.html
@@ -19,8 +19,8 @@
     <meta property="og:type" content="video" data-react-helmet="true">
     <meta property="og:url" content="{{ domain }}/#/w/{{ video.video_id }}" data-react-helmet="true">
     <meta property="og:image" content="{{ domain }}/_content/derived/{{ video.video_id }}/poster.jpg" data-react-helmet="true">
-    <meta property="og:video" content="{{ domain }}/_content/video/{{ video.video_id }}{{ video.extension }}" data-react-helmet="true">
-    <meta property="og:video:secure_url" content="{{ domain }}/_content/video/{{ video.video_id }}{{ video.extension }}" data-react-helmet="true">
+    <meta property="og:video" content="{{ domain }}/_content/derived/{{ video.video_id }}/video.m3u8" data-react-helmet="true">
+    <meta property="og:video:secure_url" content="{{ domain }}/_content/derived/{{ video.video_id }}/video.m3u8" data-react-helmet="true">
     <meta property="og:site_name" content="Fireshare" data-react-helmet="true">
     <meta property="og:title" content="{{ video.info.title }}" data-react-helmet="true">
     <meta property="og:video:width" content="{{ video.info.width }}" data-react-helmet="true">

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -72,11 +72,13 @@ def resize_m3u8(m3u8_path, height=720, fps=60):
     logger.info(f"Resizing M3U8 segment")
     cmd = [
         'ffmpeg',
-        '-v', 'quiet',
+        '-v', 'error',
         '-i', str(m3u8_path),
-        '-vf', f'scale=-2:{height},pad=ceil(iw/2)*2:ceil(ih/2)*2',
-        '-c:v', 'libx264',
+        # '-vf', f'scale=-2:{height},pad=ceil(iw/2)*2:ceil(ih/2)*2',
+        '-r', str(fps),
+        '-c:v', 'h264_videotoolbox',
         '-c:a', 'copy',
+        '-b:v', '10M',
         '-preset', 'veryfast',
         "-f", "mpegts",
         "-copyts",
@@ -91,8 +93,10 @@ def resize_m3u8(m3u8_path, height=720, fps=60):
     output, error = process.communicate()
 
     if process.returncode != 0:
-        logger.error(f'Error resizing m3u8: {error.decode()}')
-        return None
+        error_message = error.decode()
+        logger.error(f'Error converting video to M3U8: {error_message}')
+        return error_message
+        return error.decode()  # Return the FFmpeg error message
     
     e = time.time()
     logger.info(f'Converted {str(m3u8_path)} in {e-s}s')

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -61,7 +61,7 @@ def create_poster(video_path, out_path, second=0):
 def transcode_video(video_path, out_path):
     s = time.time()
     logger.info(f"Transcoding video")
-    cmd = ['ffmpeg', '-v', 'quiet', '-y', '-i', str(video_path), '-c:v', 'libx264', '-c:a', 'aac', str(out_path)]
+    cmd = ['ffmpeg', '-v', 'quiet', '-y', '-i', str(video_path), '-c:v', 'copy', '-c:a', 'copy', str(out_path)]
     logger.debug(f"$: {' '.join(cmd)}")
     sp.call(cmd)
     e = time.time()

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -58,10 +58,20 @@ def create_poster(video_path, out_path, second=0):
     e = time.time()
     logger.info(f'Generated poster {str(out_path)} in {e-s}s')
 
+def convert_video_to_m3u8(video_path, out_path):
+    s = time.time()
+    logger.info(f"Converting video to M3U8")
+    cmd = ['ffmpeg', '-v', 'quiet', '-y', '-i', str(video_path), '-c:v', 'copy', '-c:a', 'copy', str(out_path)]
+    logger.debug(f"$: {' '.join(cmd)}")
+    sp.call(cmd)
+    e = time.time()
+    logger.info(f'Converted {str(out_path)} in {e-s}s')
+
+
 def transcode_video(video_path, out_path):
     s = time.time()
     logger.info(f"Transcoding video")
-    cmd = ['ffmpeg', '-v', 'quiet', '-y', '-i', str(video_path), '-c:v', 'copy', '-c:a', 'copy', str(out_path)]
+    cmd = ['ffmpeg', '-v', 'quiet', '-y', '-i', str(video_path), '-c:v', 'libx264', '-c:a', 'aac', str(out_path)]
     logger.debug(f"$: {' '.join(cmd)}")
     sp.call(cmd)
     e = time.time()


### PR DESCRIPTION
To help mitigate bandwidth limitations and overall provide a better video viewing experience, this PR adds transcoding video + audio to m3u8, and adds the /api/video/stream endpoint to return it.

I've also updated the video-players used on the site to handle this - Previously the VideoModal used the native `video` element, it now uses ReactPlayer, like the Watch page.

There's a chance it _may_ fix discord embeds, will check soon

### Todo before ready to be merged:

- [ ] Default to direct streaming unless admin has changed default mode to transcode via toggle on settings page
- [ ] Setting for enabling or disabling transcoding totally, disable admin option for default video play mode
- [ ] Setting on video players for playback mode?
- [ ] New video uploaded and playback started before transcode done
  - [ ] Show video processing page
  - [ ] Show original video instead
  - [ ] Have an option of this behaviour?
- [ ] Properly test playback on Discord and different devices
- [ ] Option for quality of playback and a default setting? - I like having my clips high res + bitrate if I were to turn it into a video, but for little clips to share with friends it doesn't need much quality
  - [ ] Original (still HLS)
  - [ ] Low (720p30)
  - [ ] Medium (1080p60)
  - [ ] Convert beforehand or at start of request? - on-the-go (see below) is probably the only feasible option
    - [ ] Look into transcoding each segment of the video on-the-go, for proper transcoding, higher performance requirements but may reduce overall disk usage especially if having multiple quality options
  - [ ] Check if ReactPlayer has options for a YouTube-like quality selector beforehand
