### PR TITLE
Feature/issue 230 fix

### DIFF
--- a/app/client/src/views/Settings.js
+++ b/app/client/src/views/Settings.js
@@ -148,6 +148,22 @@ const Settings = ({ authenticated }) => {
                     Default Video Privacy
                   </Typography>
                 </Box>
+                
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={updatedConfig.ui_config?.show_admin_upload || false}
+                      onChange={(e) =>
+                        setUpdatedConfig((prev) => ({
+                          ...prev,
+                          ui_config: { ...prev.ui_config, show_admin_upload: e.target.checked },
+                        }))
+                      }
+                    />
+                  }
+                  label="Show Admin Upload Card"
+                />
+
                 <FormControlLabel
                   control={
                     <Checkbox
@@ -182,20 +198,6 @@ const Settings = ({ authenticated }) => {
                     />
                   }
                   label="Allow Public Upload"
-                />
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={updatedConfig.ui_config?.show_admin_upload || false}
-                      onChange={(e) =>
-                        setUpdatedConfig((prev) => ({
-                          ...prev,
-                          ui_config: { ...prev.ui_config, show_admin_upload: e.target.checked },
-                        }))
-                      }
-                    />
-                  }
-                  label="Show Admin Upload Card"
                 />
                 
                 {/* logic to show/hide checkbox in GUIbased on Parent:allow_public_upload

--- a/app/client/src/views/Settings.js
+++ b/app/client/src/views/Settings.js
@@ -174,7 +174,6 @@ const Settings = ({ authenticated }) => {
                         if (!isChecked) { 
                           try {
                             await ConfigService.updateAdminConfig(newConfig);
-                            console.log('Backend config updated: show_public_upload = false');
                           } catch (err) {
                             console.error('Failed to update backend config:', err);
                           }

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -303,7 +303,6 @@ def upload_video():
     Popen(f"fireshare scan-video --path=\"{save_path}\"", shell=True)
     return Response(status=201)
 
-
 @api.route('/api/video')
 def get_video():
     video_id = request.args.get('id')
@@ -341,39 +340,3 @@ def get_video():
 def after_request(response):
     response.headers.add('Accept-Ranges', 'bytes')
     return response
-
-
-def get_folder_size(folder_path):
-    total_size = 0
-    for dirpath, dirnames, filenames in os.walk(folder_path):
-        for f in filenames:
-            fp = os.path.join(dirpath, f)
-            if os.path.isfile(fp):  # Avoid broken symlinks
-                total_size += os.path.getsize(fp)
-    return total_size
-
-@api.route('/api/folder-size', methods=['GET'])
-def folder_size():
-    print("Folder size endpoint was hit!")  # Debugging line
-    path = request.args.get('path', default='.', type=str)
-    size_bytes = get_folder_size(path)
-    size_mb = size_bytes / (1024 * 1024)
-
-    if size_mb < 1024:
-        rounded_mb = round(size_mb / 100) * 100
-        size_pretty = f"{rounded_mb} MB"
-    elif size_mb < 1024 * 1024:
-        size_gb = size_mb / 1024
-        size_pretty = f"{round(size_gb, 1)} GB"
-    else:
-        size_tb = size_mb / (1024 * 1024)
-        size_pretty = f"{round(size_tb, 1)} TB"
-
-    return jsonify({
-        "folder": path,
-        "size_bytes": size_bytes,
-        "size_pretty": size_pretty
-    })
-
-
-


### PR DESCRIPTION
Fix for issue #230 

This fix does 2 things. 
1. It will hide the checkbox card from settings.py if the parent allow_public_uplods is also hidden.

2. Even if the box show_public_upload checked on the GUI when the settings are saved there is logic in allow_public_uplods to set 
```
allow_public_uplods - false 
show_public_upload - false
```
if the allow_public_uplods  checkbox is unchecked. Basically making show_public_upload a child option of allow_public_upload

![Screenshot 2025-05-05 140811](https://github.com/user-attachments/assets/58d4e0eb-0305-4af5-bee0-f3db3109e68a)
![Screenshot 2025-05-05 140759](https://github.com/user-attachments/assets/1f85136b-26f6-470d-a666-49791534285b)