### PR TITLE
Send discord webhooks on full scan

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fireshare",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -65,13 +65,14 @@ def add_user(username, password):
 @click.option("--root", "-r", help="root video path to scan", required=False)
 def scan_videos(root):
     with create_app().app_context():
-        domain = current_app.config['DOMAIN']
         paths = current_app.config['PATHS']
+        domain = current_app.config['DOMAIN']
         videos_path = paths["video"]
         video_links = paths["processed"] / "video_links"
+
         config_file = open(paths["data"] / "config.json")
         config = json.load(config_file)
-        video_config = json.load(config_file)["app_config"]["video_defaults"]
+        video_config = config["app_config"]["video_defaults"]
         discord_webhook_url = config["integrations"]["discord_webhook_url"]
         config_file.close()
         


### PR DESCRIPTION
Before discord webhooks were only being sent on uploaded videos only. This has been updated to also send them for new videos that are scanned in that may have been directly dropped into the video directory.