### PR TITLE
Fix Large Files Failing To Upload

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fireshare",
-  "version": "1.2.27",
+  "version": "1.2.28",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/app/client/src/components/admin/UploadCard.js
+++ b/app/client/src/components/admin/UploadCard.js
@@ -98,7 +98,10 @@ const UploadCard = ({ authenticated, feedView = false, publicUpload = false, fet
       if (!selectedFile) return;
 
       const totalChunks = Math.ceil(selectedFile.size / chunkSize);
-      const checksum = await crypto.subtle.digest('SHA-256', await selectedFile.arrayBuffer()).then(buf => Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join(''));
+      
+      const fileInfo = `${selectedFile.name}-${selectedFile.size}-${selectedFile.lastModified}`;
+      const checksum = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(fileInfo))
+        .then(buf => Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join(''));
 
       try {
         for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {


### PR DESCRIPTION
Checking the checksum of large files was causing problems and creating errors. Instead use a more efficient checksum that looks at the file info instead of the file contents. 