### PR TITLE
Develop

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fireshare",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/app/client/src/components/admin/UploadCard.js
+++ b/app/client/src/components/admin/UploadCard.js
@@ -114,6 +114,10 @@ const UploadCard = ({ authenticated, feedView = false, publicUpload = false, fet
           formData.append('chunkPart', chunkIndex + 1);
           formData.append('totalChunks', totalChunks);
           formData.append('checkSum', checksum);
+          formData.append('fileName', selectedFile.name);
+          formData.append('fileSize', selectedFile.size.toString());
+          formData.append('lastModified', selectedFile.lastModified.toString());
+          formData.append('fileType', selectedFile.type);
 
           if (publicUpload) {
             await VideoService.publicUploadChunked(formData, uploadProgressChunked, selectedFile.size, start);
@@ -141,7 +145,6 @@ const UploadCard = ({ authenticated, feedView = false, publicUpload = false, fet
       setUploadRate(null);
       setIsSelected(false);
     }
-
 
     if (selectedFile.size > chunkSize) {
       uploadChunked()

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -187,21 +187,21 @@ def delete_video(id):
     video = Video.query.filter_by(video_id=id).first()
     if video:
         logging.info(f"Deleting video: {video.video_id}")
+        
+        paths = current_app.config['PATHS']
+        file_path = paths['video'] / video.path
+        link_path = paths['processed'] / 'video_links' / f"{id}{video.extension}"
+        derived_path = paths['processed'] / 'derived' / id
+        
         VideoInfo.query.filter_by(video_id=id).delete()
         Video.query.filter_by(video_id=id).delete()
         db.session.commit()
-        
-        # Use the PATHS config for consistent path handling
-        paths = current_app.config['PATHS']
-        file_path = paths['video'] / video.path
-        link_path = paths['processed'] / 'video_links' / f"{id}.{video.extension}"
-        derived_path = paths['processed'] / 'derived' / id
         
         try:
             if file_path.exists():
                 file_path.unlink()
                 logging.info(f"Deleted video file: {file_path}")
-            if link_path.exists():
+            if link_path.exists() or link_path.is_symlink():
                 link_path.unlink()
                 logging.info(f"Deleted link file: {link_path}")
             if derived_path.exists():
@@ -209,6 +209,7 @@ def delete_video(id):
                 logging.info(f"Deleted derived directory: {derived_path}")
         except OSError as e:
             logging.error(f"Error deleting files for video {id}: {e}")
+            logging.error(f"Attempted to delete: file={file_path}, link={link_path}, derived={derived_path}")
         return Response(status=200)
         
     else:
@@ -402,19 +403,22 @@ def upload_videoChunked():
     upload_folder = config['app_config']['admin_upload_folder_name']
 
     required_files = ['blob']
-    required_form_fields = ['chunkPart', 'totalChunks', 'checkSum']
+    required_form_fields = ['chunkPart', 'totalChunks', 'checkSum', 'fileName', 'fileSize']
 
     if not all(key in request.files for key in required_files) or not all(key in request.form for key in required_form_fields):
         return Response(status=400)
+        
     blob = request.files.get('blob')
     chunkPart = int(request.form.get('chunkPart'))
     totalChunks = int(request.form.get('totalChunks'))
     checkSum = request.form.get('checkSum')
-    if not blob.filename or blob.filename.strip() == '' or blob.filename == 'blob':
+    fileName = request.form.get('fileName')
+    fileSize = int(request.form.get('fileSize'))
+    
+    if not fileName or fileName.strip() == '':
         return Response(status=400)
     
-    filename = blob.filename
-    filetype = blob.filename.split('.')[-1] # TODO, probe filetype with fmpeg instead and remux
+    filetype = fileName.split('.')[-1]
     if not filetype in SUPPORTED_FILE_TYPES:
         return Response(status=400)
     
@@ -422,21 +426,56 @@ def upload_videoChunked():
     if not os.path.exists(upload_directory):
         os.makedirs(upload_directory)
     
-    tempPath = os.path.join(upload_directory, f"{checkSum}.{filetype}")
-    with open(tempPath, 'ab') as f:
+    # Store chunks with part number to ensure proper ordering
+    tempPath = os.path.join(upload_directory, f"{checkSum}.part{chunkPart:04d}")
+    
+    # Write this specific chunk
+    with open(tempPath, 'wb') as f:
         f.write(blob.read())
 
-    if chunkPart < totalChunks:
+    # Check if we have all chunks
+    chunk_files = []
+    for i in range(1, totalChunks + 1):
+        chunk_path = os.path.join(upload_directory, f"{checkSum}.part{i:04d}")
+        if os.path.exists(chunk_path):
+            chunk_files.append(chunk_path)
+    
+    # If we don't have all chunks yet, return 202
+    if len(chunk_files) != totalChunks:
         return Response(status=202)
 
-    save_path = os.path.join(upload_directory, filename)
-
-    if (os.path.exists(save_path)):
-        name_no_type = ".".join(filename.split('.')[0:-1])
+    # All chunks received, reassemble the file
+    save_path = os.path.join(upload_directory, fileName)
+    
+    if os.path.exists(save_path):
+        name_no_type = ".".join(fileName.split('.')[0:-1])
         uid = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(6))
-        save_path = os.path.join(paths['video'], upload_folder, f"{name_no_type}-{uid}.{filetype}")
+        save_path = os.path.join(upload_directory, f"{name_no_type}-{uid}.{filetype}")
 
-    os.rename(tempPath, save_path)
+    # Reassemble chunks in correct order
+    try:
+        with open(save_path, 'wb') as output_file:
+            for i in range(1, totalChunks + 1):
+                chunk_path = os.path.join(upload_directory, f"{checkSum}.part{i:04d}")
+                with open(chunk_path, 'rb') as chunk_file:
+                    output_file.write(chunk_file.read())
+                # Clean up chunk file
+                os.remove(chunk_path)
+        
+        # Verify file size
+        if os.path.getsize(save_path) != fileSize:
+            os.remove(save_path)
+            return Response(status=500, response="File size mismatch after reassembly")
+            
+    except Exception as e:
+        # Clean up on error
+        for chunk_path in chunk_files:
+            if os.path.exists(chunk_path):
+                os.remove(chunk_path)
+        if os.path.exists(save_path):
+            os.remove(save_path)
+        return Response(status=500, response="Error reassembling file")
+
     Popen(f"fireshare scan-video --path=\"{save_path}\"", shell=True)
     return Response(status=201)
 

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -52,7 +52,7 @@ def get_media_info(path):
 
 def create_poster(video_path, out_path, second=0):
     s = time.time()
-    cmd = ['ffmpeg', '-v', 'quiet', '-y', '-i', str(video_path), '-ss', str(second), '-vframes', '1', str(out_path)]
+    cmd = ['ffmpeg', '-v', 'quiet', '-y', '-i', str(video_path), '-ss', str(second), '-vframes', '1', '-vf', 'scale=iw:ih:force_original_aspect_ratio=decrease', str(out_path)]
     logger.debug(f"$ {' '.join(cmd)}")
     sp.call(cmd)
     e = time.time()


### PR DESCRIPTION
This pull request introduces improvements to the chunked video upload process, enhances file deletion reliability, and ensures chunk files are excluded from video scans. The main changes focus on making uploads more robust by tracking additional file metadata, reassembling chunks safely, and cleaning up intermediate files. There are also updates to video deletion and scanning logic to better handle chunked uploads.

**Chunked Upload Improvements**
- Added `fileName`, `fileSize`, `lastModified`, and `fileType` fields to the upload form data in `UploadCard.js`, ensuring the server receives all necessary metadata for file validation and reassembly.
- On the server side (`api.py`), chunk files are now saved with part numbers (`.part0001`, etc.), and the server waits until all chunks are received before reassembling them in order. The server verifies the final file size and cleans up chunk files after assembly, returning errors if there are mismatches or failures.

**File Deletion and Cleanup**
- Improved the video deletion endpoint to use `pathlib` for file operations, add logging, and more robustly handle deletion of video files, links, and derived directories. This ensures all associated files are cleaned up and errors are logged with more detail.

**Video Scanning Reliability**
- Updated the video scanning logic (`cli.py`) to ignore chunk files (those ending with `.part####`) when scanning for new videos, preventing incomplete uploads from being processed as valid videos. [[1]](diffhunk://#diff-326b559662f48d754e3fa59a3d2dcb98263d3fbff881a1e9025770872faf7316L83-R88) [[2]](diffhunk://#diff-326b559662f48d754e3fa59a3d2dcb98263d3fbff881a1e9025770872faf7316L177-R185)

**Other Updates**
- Adjusted the ffmpeg command in `create_poster` to force the original aspect ratio when generating video posters, improving thumbnail consistency.
- Bumped the client package version to `1.2.30` to reflect these changes.