### PR TITLE
Game Detection now scans folders path for name, Add Clear database button for testing

### DIFF
--- a/app/client/src/services/ConfigService.js
+++ b/app/client/src/services/ConfigService.js
@@ -12,6 +12,10 @@ const service = {
       config,
     })
   },
+  resetDatabase(options) {
+    const payload = options ? { options } : undefined
+    return Api().post('/api/admin/reset-database', payload)
+  },
 }
 
 export default service

--- a/app/client/src/views/Settings.js
+++ b/app/client/src/views/Settings.js
@@ -3,6 +3,11 @@ import {
   Box,
   Button,
   Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Divider,
   FormControlLabel,
   Grid,
@@ -15,6 +20,7 @@ import SnackbarAlert from '../components/alert/SnackbarAlert'
 import SaveIcon from '@mui/icons-material/Save'
 import SensorsIcon from '@mui/icons-material/Sensors'
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports'
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import { ConfigService, VideoService } from '../services'
@@ -35,7 +41,21 @@ const Settings = ({ authenticated }) => {
   const [updateable, setUpdateable] = React.useState(false)
   const [discordUrl, setDiscordUrl] = React.useState('')
   const [showSteamGridKey, setShowSteamGridKey] = React.useState(false)
+  const [resetDialogOpen, setResetDialogOpen] = React.useState(false)
+  const [resetting, setResetting] = React.useState(false)
+  const defaultResetOptions = {
+    game_links: false,
+    game_suggestions: false,
+    game_metadata: false,
+    game_assets: false,
+    video_views: false,
+    video_metadata: false,
+    videos: false,
+    processed_files: false,
+  }
+  const [resetOptions, setResetOptions] = React.useState(defaultResetOptions)
   const isDiscordUsed = discordUrl.trim() !== ''
+  const hasResetSelection = Object.values(resetOptions).some(Boolean)
 
 
   React.useEffect(() => {
@@ -113,6 +133,33 @@ const Settings = ({ authenticated }) => {
         })
       }
     }
+  }
+
+  const handleResetDatabase = async () => {
+    setResetting(true)
+    try {
+      await ConfigService.resetDatabase(resetOptions)
+      setResetDialogOpen(false)
+      setAlert({
+        open: true,
+        type: 'success',
+        message: 'Database reset successfully. You can now run a fresh scan.',
+      })
+    } catch (err) {
+      console.error(err)
+      setAlert({
+        open: true,
+        type: 'error',
+        message: err.response?.data || 'Failed to reset database',
+      })
+    } finally {
+      setResetting(false)
+    }
+  }
+
+  const openResetDialog = () => {
+    setResetOptions(defaultResetOptions)
+    setResetDialogOpen(true)
   }
 
   const checkForWarnings  = async () =>{
@@ -457,10 +504,126 @@ const Settings = ({ authenticated }) => {
               <Button variant="contained" startIcon={<SportsEsportsIcon />} onClick={handleScanGames}>
                 Start Manual Scan for Missing Games
               </Button>
+              <Button
+                variant="contained"
+                color="error"
+                startIcon={<DeleteForeverIcon />}
+                onClick={openResetDialog}
+                disabled={resetting}
+              >
+                Reset Database
+              </Button>
             </Box>
           </Grid>
         </Grid>
       </Box>
+      <Dialog open={resetDialogOpen} onClose={() => !resetting && setResetDialogOpen(false)}>
+        <DialogTitle>Reset Database?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Select what to remove. Deleting videos also removes video info, views, game links, and processed files.
+            Deleting game metadata also removes game links and game assets. Your original video files on disk are not
+            removed.
+          </DialogContentText>
+          <Stack spacing={1} sx={{ mt: 2 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={resetOptions.game_links}
+                  onChange={() => setResetOptions((prev) => ({ ...prev, game_links: !prev.game_links }))}
+                  disabled={resetting}
+                />
+              }
+              label="Game links (unlink clips from games)"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={resetOptions.game_suggestions}
+                  onChange={() => setResetOptions((prev) => ({ ...prev, game_suggestions: !prev.game_suggestions }))}
+                  disabled={resetting}
+                />
+              }
+              label="Game suggestions"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={resetOptions.game_metadata}
+                  onChange={() => setResetOptions((prev) => ({ ...prev, game_metadata: !prev.game_metadata }))}
+                  disabled={resetting}
+                />
+              }
+              label="Game metadata (game list)"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={resetOptions.game_assets}
+                  onChange={() => setResetOptions((prev) => ({ ...prev, game_assets: !prev.game_assets }))}
+                  disabled={resetting}
+                />
+              }
+              label="Game assets (downloaded images)"
+            />
+            <Divider />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={resetOptions.video_views}
+                  onChange={() => setResetOptions((prev) => ({ ...prev, video_views: !prev.video_views }))}
+                  disabled={resetting}
+                />
+              }
+              label="Video views"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={resetOptions.video_metadata}
+                  onChange={() => setResetOptions((prev) => ({ ...prev, video_metadata: !prev.video_metadata }))}
+                  disabled={resetting}
+                />
+              }
+              label="Video titles and descriptions (reset to filename)"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={resetOptions.videos}
+                  onChange={() => setResetOptions((prev) => ({ ...prev, videos: !prev.videos }))}
+                  disabled={resetting}
+                />
+              }
+              label="Videos (remove all videos from the library)"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={resetOptions.processed_files}
+                  onChange={() => setResetOptions((prev) => ({ ...prev, processed_files: !prev.processed_files }))}
+                  disabled={resetting}
+                />
+              }
+              label="Processed files (symlinks and derived)"
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setResetDialogOpen(false)} disabled={resetting}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            startIcon={<DeleteForeverIcon />}
+            onClick={handleResetDatabase}
+            disabled={resetting || !hasResetSelection}
+          >
+            {resetting ? 'Resetting...' : 'Reset Database'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </>
   )
 }


### PR DESCRIPTION
Autodetect system now prioritizes folder path names for matching to Games database. 
<img width="776" height="468" alt="Screenshot 2026-01-17 at 11 38 00 AM" src="https://github.com/user-attachments/assets/32c82a7f-46cf-4317-988f-d5f138aad9a6" />


Additionally, added a quick "reset database" button in settings.js to temporarily test things like clearing game links, views, etc. This can be removed/hidden upon public release. Figured this will be easier to mass strip game links to video clips while we're testing the autodetect feature.
<img width="1033" height="795" alt="Screenshot 2026-01-17 at 2 07 02 PM" src="https://github.com/user-attachments/assets/f9c9a6c9-ac08-4155-82c1-897207bbb955" />
