### PR TITLE
Add select all/none button in edit mode

### DIFF
--- a/app/client/src/views/Dashboard.js
+++ b/app/client/src/views/Dashboard.js
@@ -167,6 +167,16 @@ const Dashboard = ({ authenticated, searchText, cardSize, listStyle, showRelease
     }
   }
 
+  const allSelected = sortedVideos.length > 0 && selectedVideos.size === sortedVideos.length
+
+  const handleSelectAllToggle = () => {
+    if (allSelected) {
+      setSelectedVideos(new Set())
+    } else {
+      setSelectedVideos(new Set(sortedVideos.map((v) => v.video_id)))
+    }
+  }
+
   const handleVideoSelect = (videoId) => {
     const newSelected = new Set(selectedVideos)
     if (newSelected.has(videoId)) {
@@ -334,7 +344,17 @@ const Dashboard = ({ authenticated, searchText, cardSize, listStyle, showRelease
             {authenticated && (
               <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2, gap: 2, px: 3 }}>
                 {editMode && (
-                  <>
+                  <Box sx={{ display: 'flex' }}>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      onClick={handleSelectAllToggle}
+                      sx={{
+                        borderRadius: '8px 0 0 8px',
+                      }}
+                    >
+                      {allSelected ? 'Select None' : 'Select All'}
+                    </Button>
                     <Button
                       variant="contained"
                       color="primary"
@@ -342,7 +362,7 @@ const Dashboard = ({ authenticated, searchText, cardSize, listStyle, showRelease
                       onClick={handleLinkGameClick}
                       disabled={selectedVideos.size === 0}
                       sx={{
-                        borderRadius: '8px',
+                        borderRadius: 0,
                       }}
                     >
                       Link to Game {selectedVideos.size > 0 && `(${selectedVideos.size})`}
@@ -354,12 +374,12 @@ const Dashboard = ({ authenticated, searchText, cardSize, listStyle, showRelease
                       onClick={handleDeleteClick}
                       disabled={selectedVideos.size === 0}
                       sx={{
-                        borderRadius: '8px',
+                        borderRadius: '0 8px 8px 0',
                       }}
                     >
                       Delete {selectedVideos.size > 0 && `(${selectedVideos.size})`}
                     </Button>
-                  </>
+                  </Box>
                 )}
                 <IconButton
                   onClick={handleEditModeToggle}

--- a/app/client/src/views/Games.js
+++ b/app/client/src/views/Games.js
@@ -70,6 +70,16 @@ const Games = ({ authenticated, searchText }) => {
     }
   }
 
+  const allSelected = filteredGames.length > 0 && selectedGames.size === filteredGames.length
+
+  const handleSelectAllToggle = () => {
+    if (allSelected) {
+      setSelectedGames(new Set())
+    } else {
+      setSelectedGames(new Set(filteredGames.map((g) => g.steamgriddb_id)))
+    }
+  }
+
   const handleGameSelect = (gameId) => {
     const newSelected = new Set(selectedGames)
     if (newSelected.has(gameId)) {
@@ -125,18 +135,30 @@ const Games = ({ authenticated, searchText }) => {
       {/* Edit button and Delete button */}
       <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2, gap: 2, alignItems: 'flex-start' }}>
         {editMode && (
-          <Button
-            variant="contained"
-            color="error"
-            startIcon={<DeleteIcon />}
-            onClick={handleDeleteClick}
-            disabled={selectedGames.size === 0}
-            sx={{
-              borderRadius: '8px',
-            }}
-          >
-            Delete {selectedGames.size > 0 && `(${selectedGames.size})`}
-          </Button>
+          <Box sx={{ display: 'flex' }}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSelectAllToggle}
+              sx={{
+                borderRadius: '8px 0 0 8px',
+              }}
+            >
+              {allSelected ? 'Select None' : 'Select All'}
+            </Button>
+            <Button
+              variant="contained"
+              color="error"
+              startIcon={<DeleteIcon />}
+              onClick={handleDeleteClick}
+              disabled={selectedGames.size === 0}
+              sx={{
+                borderRadius: '0 8px 8px 0',
+              }}
+            >
+              Delete {selectedGames.size > 0 && `(${selectedGames.size})`}
+            </Button>
+          </Box>
         )}
         {authenticated && (
           <IconButton


### PR DESCRIPTION
Added a Select All/None option in the edit button page. Also simplified some of the styling to remain more cohesive.
<img width="461" height="110" alt="Screenshot 2026-02-06 at 6 33 47 PM" src="https://github.com/user-attachments/assets/eadb65e6-c022-4ae7-a005-3d58b148ff1f" />
