### PR TITLE
Fix filenames having underscores instead of spaces.

### DIFF
--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -13,7 +13,6 @@ from flask_cors import CORS
 from sqlalchemy.sql import text
 from pathlib import Path
 import requests
-# from werkzeug.utils import secure_filename
 
 
 from . import db, logger, util


### PR DESCRIPTION
Changed the functionality of the secure_filename function to revert to using without imports and not to exclude underscores and dashes in a safe manner, as mentioned in #411 

Changes:

Removed the import of werkzeug.secure_filename and reimplemented secure_filename at the start of api.py. It was done in a safe manner using regex, to be safe for all systems including Windows, Linux, and MacOS. Reference [This StackOverflow thread](https://stackoverflow.com/questions/7406102/create-sane-safe-filename-from-any-unsafe-string) which in turn references this [documentation](https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words) about reserved characters for all operating systems.

@ShaneIsrael 