### PR TITLE
Handle missing video stream in metadata sync

### DIFF
--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -482,7 +482,12 @@ def sync_metadata(video):
                     position = current_app.config['WARNINGS'].index(corruptVideoWarning)
                     current_app.config['WARNINGS'].pop(position)
 
-                vcodec = [i for i in info if i['codec_type'] == 'video'][0]
+                video_codecs = [i for i in info if i['codec_type'] == 'video']
+                if not video_codecs:
+                    logger.warning(f"No video stream found in {v.video.path} (video_id={v.video_id}). Skipping metadata sync.")
+                    mark_video_corrupt(v.video_id)
+                    continue
+                vcodec = video_codecs[0]
                 duration = 0
                 if 'duration' in vcodec:
                     duration = float(vcodec['duration'])


### PR DESCRIPTION
Full disclosure this PR was generated with Copilot.

I was continually running into an issue where something about a file's metadata would kill the entire scan. This PR adds a sanity check to prevent a file from locking the entire container when it fails to read the metadata.
<img width="855" height="426" alt="image" src="https://github.com/user-attachments/assets/dace739e-da8e-484b-b654-f9a585f5e0b9" />
