### PR TITLE
Calculate video player sizing dynamically regardless of aspect ratio

### DIFF
--- a/app/client/src/components/misc/VideoJSPlayer.js
+++ b/app/client/src/components/misc/VideoJSPlayer.js
@@ -16,7 +16,9 @@ const VideoJSPlayer = ({
   sources, 
   poster, 
   autoplay = false, 
-  controls = true, 
+  controls = true,
+  fluid = true,
+  fill = false,
   onTimeUpdate, 
   onReady,
   startTime,
@@ -45,6 +47,8 @@ const VideoJSPlayer = ({
         autoplay,
         controls,
         responsive: true,
+        fluid,
+        fill,
         poster,
         preload: 'auto',
         html5: {
@@ -146,7 +150,7 @@ const VideoJSPlayer = ({
   }, [])
 
   return (
-    <div data-vjs-player className={className} style={style}>
+    <div data-vjs-player className={className} style={{ maxWidth: '100%', ...style }}>
       <video ref={videoRef} className="video-js vjs-big-play-centered" />
     </div>
   )

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -31,6 +31,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   const [selectedGame, setSelectedGame] = React.useState(null)
 
   const playerRef = React.useRef()
+  const videoContainerRef = React.useRef(null)
 
   const getRandomVideo = async () => {
     try {
@@ -233,6 +234,35 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
     return `${URL}/api/video/poster?id=${vid.video_id}`
   }
 
+  // Constrain video player dimensions to fit within available space while maintaining aspect ratio
+  React.useEffect(() => {
+    const container = videoContainerRef.current
+    if (!container) return
+
+    const aspectRatio = (vid?.info?.width && vid?.info?.height)
+      ? vid.info.width / vid.info.height
+      : 16 / 9
+
+    const computeSize = () => {
+      const availW = container.clientWidth
+      const availH = container.clientHeight
+      if (availW <= 0 || availH <= 0) return
+
+      let w = availW
+      let h = w / aspectRatio
+
+      if (h > availH) {
+        h = availH
+        w = h * aspectRatio
+      }
+    }
+
+    const observer = new ResizeObserver(computeSize)
+    observer.observe(container)
+
+    return () => observer.disconnect()
+  }, [vid?.info?.width, vid?.info?.height])
+
   if (!vid) return null
 
   return (
@@ -263,193 +293,172 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
             >
               <CloseIcon sx={{ width: 35, height: 35 }} />
             </IconButton>
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                height: 'calc(100% - 20px)',
-                overflow: 'hidden',
-              }}
-            >
-              {/* Video player area - shrinks to make room for controls */}
-              <Box
-                sx={{
-                  flex: 1,
-                  minHeight: 0,
-                  width: '100%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <VideoJSPlayer
-                  key={vid.video_id}
-                  sources={getVideoSources(vid.video_id, vid?.info, vid.extension)}
-                  poster={getPosterUrl()}
-                  autoplay={autoplay}
-                  controls={true}
-                  onTimeUpdate={handleTimeUpdate}
-                  onReady={(player) => {
-                    playerRef.current = player
-                  }}
-                />
-              </Box>
-              {/* Controls area - always visible at bottom */}
-              <Box sx={{ flexShrink: 0, width: '100%', pb: 1 }}>
-                <Grid container justifyContent="center" sx={{ mt: 1 }}>
-                  <Grid item>
-                    <ButtonGroup variant="contained" onClick={(e) => e.stopPropagation()}>
-                      <Button onClick={getRandomVideo}>
-                        <ShuffleIcon />
-                      </Button>
-                      {authenticated && (
-                        <Button onClick={handlePrivacyChange} edge="end">
-                          {privateView ? <VisibilityOffIcon /> : <VisibilityIcon />}
-                        </Button>
-                      )}
-                      <TextField
+            <div style={{ display: 'flex', height: '100%', flexDirection: 'column', alignItems: 'center' }}>
+              <div ref={videoContainerRef} style={{ flex: '1 1 auto', minHeight: 0, width: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                  <VideoJSPlayer
+                    key={vid.video_id}
+                    sources={getVideoSources(vid.video_id, vid?.info, vid.extension)}
+                    poster={getPosterUrl()}
+                    autoplay={autoplay}
+                    controls={true}
+                    onTimeUpdate={handleTimeUpdate}
+                    onReady={(player) => {
+                      playerRef.current = player
+                    }}
+                    fluid={false}
+                    fill={true}
+                  />
+              </div>
+              <div style={{ flex: '0 0 auto', marginTop: 8, marginBottom: 8}}>
+                <ButtonGroup variant="contained" onClick={(e) => e.stopPropagation()}>
+                  <Button onClick={getRandomVideo}>
+                    <ShuffleIcon />
+                  </Button>
+                  {authenticated && (
+                    <Button onClick={handlePrivacyChange} edge="end">
+                      {privateView ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                    </Button>
+                  )}
+                  <TextField
+                    sx={{
+                      textAlign: 'center',
+                      background: 'rgba(50, 50, 50, 0.9)',
+                      '& .MuiOutlinedInput-root': {
+                        borderRadius: 0,
+                        width: {
+                          xs: 'auto',
+                          sm: 350,
+                          md: 450,
+                        },
+                      },
+                      '& .MuiInputBase-input.Mui-disabled': {
+                        WebkitTextFillColor: '#fff',
+                      },
+                    }}
+                    size="small"
+                    value={title}
+                    placeholder="Video Title"
+                    disabled={!authenticated}
+                    onChange={(e) => handleTitleChange(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && update()}
+                    InputProps={{
+                      endAdornment: authenticated && (
+                        <InputAdornment position="end">
+                          <IconButton
+                            disabled={!updateable}
+                            sx={
+                              updateable
+                                ? {
+                                    animation: 'blink-blue 0.5s ease-in-out infinite alternate',
+                                  }
+                                : {}
+                            }
+                            onClick={update}
+                            edge="end"
+                          >
+                            <SaveIcon />
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    }}
+                  />
+                  <CopyToClipboard text={`${PURL}${vid.video_id}`}>
+                    <Button
+                      onMouseDown={handleMouseDown}
+                      onClick={() =>
+                        setAlert({
+                          type: 'info',
+                          message: 'Link copied to clipboard',
+                          open: true,
+                        })
+                      }
+                    >
+                      <LinkIcon />
+                    </Button>
+                  </CopyToClipboard>
+                  <Button onClick={copyTimestamp}>
+                    <AccessTimeIcon />
+                  </Button>
+                </ButtonGroup>
+                {(authenticated || description) && (
+                  <Paper sx={{ mt: 1, background: 'rgba(50, 50, 50, 0.9)' }}>
+                    <TextField
+                      fullWidth
+                      disabled={!authenticated}
+                      sx={{
+                        '& .MuiInputBase-input.Mui-disabled': {
+                          WebkitTextFillColor: '#fff',
+                        },
+                        '& .MuiOutlinedInput-notchedOutline': {
+                          border: 'none',
+                        },
+                      }}
+                      size="small"
+                      placeholder="Enter a video description..."
+                      value={description || ''}
+                      onChange={(e) => handleDescriptionChange(e.target.value)}
+                      rows={2}
+                      multiline
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </Paper>
+                )}
+                {/* Game linking */}
+                {(authenticated || getSetting('ui_config')?.allow_public_game_tag) && (
+                  <Paper sx={{ mt: 1, background: 'rgba(50, 50, 50, 0.9)' }}>
+                    {selectedGame ? (
+                      <Box
                         sx={{
-                          textAlign: 'center',
-                          background: 'rgba(50, 50, 50, 0.9)',
-                          '& .MuiOutlinedInput-root': {
-                            borderRadius: 0,
-                            width: {
-                              xs: 'auto',
-                              sm: 350,
-                              md: 450,
-                            },
-                          },
-                          '& .MuiInputBase-input.Mui-disabled': {
-                            WebkitTextFillColor: '#fff',
-                          },
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          height: 40,
+                          pl: 1.75,
+                          pr: 0.5,
                         }}
-                        size="small"
-                        value={title}
-                        placeholder="Video Title"
-                        disabled={!authenticated}
-                        onChange={(e) => handleTitleChange(e.target.value)}
-                        onKeyDown={(e) => e.key === 'Enter' && update()}
-                        InputProps={{
-                          endAdornment: authenticated && (
-                            <InputAdornment position="end">
-                              <IconButton
-                                disabled={!updateable}
-                                sx={
-                                  updateable
-                                    ? {
-                                        animation: 'blink-blue 0.5s ease-in-out infinite alternate',
-                                      }
-                                    : {}
-                                }
-                                onClick={update}
-                                edge="end"
-                              >
-                                <SaveIcon />
-                              </IconButton>
-                            </InputAdornment>
-                          ),
-                        }}
-                      />
-                      <CopyToClipboard text={`${PURL}${vid.video_id}`}>
-                        <Button
-                          onMouseDown={handleMouseDown}
-                          onClick={() =>
-                            setAlert({
-                              type: 'info',
-                              message: 'Link copied to clipboard',
-                              open: true,
-                            })
-                          }
-                        >
-                          <LinkIcon />
-                        </Button>
-                      </CopyToClipboard>
-                      <Button onClick={copyTimestamp}>
-                        <AccessTimeIcon />
-                      </Button>
-                    </ButtonGroup>
-                    {(authenticated || description) && (
-                      <Paper sx={{ mt: 1, background: 'rgba(50, 50, 50, 0.9)' }}>
-                        <TextField
-                          fullWidth
-                          disabled={!authenticated}
-                          sx={{
-                            '& .MuiInputBase-input.Mui-disabled': {
-                              WebkitTextFillColor: '#fff',
-                            },
-                            '& .MuiOutlinedInput-notchedOutline': {
-                              border: 'none',
-                            },
-                          }}
-                          size="small"
-                          placeholder="Enter a video description..."
-                          value={description || ''}
-                          onChange={(e) => handleDescriptionChange(e.target.value)}
-                          rows={2}
-                          multiline
-                          onClick={(e) => e.stopPropagation()}
-                        />
-                      </Paper>
-                    )}
-                    {/* Game linking */}
-                    {(authenticated || getSetting('ui_config')?.allow_public_game_tag) && (
-                      <Paper sx={{ mt: 1, background: 'rgba(50, 50, 50, 0.9)' }}>
-                        {selectedGame ? (
+                      >
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <SportsEsportsIcon sx={{ color: 'rgba(255, 255, 255, 0.7)' }} />
                           <Box
+                            component="span"
                             sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'space-between',
-                              height: 40,
-                              pl: 1.75,
-                              pr: 0.5,
+                              color: 'rgba(255, 255, 255, 0.7)',
+                              fontSize: '0.875rem',
                             }}
                           >
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                              <SportsEsportsIcon sx={{ color: 'rgba(255, 255, 255, 0.7)' }} />
-                              <Box
-                                component="span"
-                                sx={{
-                                  color: 'rgba(255, 255, 255, 0.7)',
-                                  fontSize: '0.875rem',
-                                }}
-                              >
-                                {selectedGame.name}
-                              </Box>
-                            </Box>
-                            <IconButton
-                              onClick={handleUnlinkGame}
-                              size="small"
-                              sx={{
-                                color: 'rgba(255, 255, 255, 0.5)',
-                                '&:hover': {
-                                  color: 'rgba(255, 255, 255, 0.9)',
-                                },
-                              }}
-                            >
-                              <CloseIcon fontSize="small" />
-                            </IconButton>
+                            {selectedGame.name}
                           </Box>
-                        ) : (
-                          <GameSearch
-                            onGameLinked={handleGameLinked}
-                            onError={(err) =>
-                              setAlert({
-                                open: true,
-                                type: 'error',
-                                message: err.response?.data || 'Error linking game',
-                              })
-                            }
-                            placeholder="Search for a game..."
-                          />
-                        )}
-                      </Paper>
+                        </Box>
+                        <IconButton
+                          onClick={handleUnlinkGame}
+                          size="small"
+                          sx={{
+                            color: 'rgba(255, 255, 255, 0.5)',
+                            '&:hover': {
+                              color: 'rgba(255, 255, 255, 0.9)',
+                            },
+                          }}
+                        >
+                          <CloseIcon fontSize="small" />
+                        </IconButton>
+                      </Box>
+                    ) : (
+                      <GameSearch
+                        onGameLinked={handleGameLinked}
+                        onError={(err) =>
+                          setAlert({
+                            open: true,
+                            type: 'error',
+                            message: err.response?.data || 'Error linking game',
+                          })
+                        }
+                        placeholder="Search for a game..."
+                      />
                     )}
-                  </Grid>
-                </Grid>
-              </Box>
-            </Box>
+                  </Paper>
+                )}
+              </div>
+            </div>
           </Paper>
         </Slide>
       </Modal>

--- a/app/client/src/components/nav/Navbar20.js
+++ b/app/client/src/components/nav/Navbar20.js
@@ -587,6 +587,7 @@ function Navbar20({
           flexGrow: 1,
           p: page !== '/w' ? mainPadding : 0,
           width: { sm: `calc(100% - ${open ? drawerWidth : minimizedDrawerWidth}px)` },
+          height: 'calc(100vh - 64px)',
         }}
       >
         {toolbar && <Toolbar />}

--- a/app/client/src/views/Watch.js
+++ b/app/client/src/views/Watch.js
@@ -31,7 +31,36 @@ const Watch = ({ authenticated }) => {
   const [viewAdded, setViewAdded] = React.useState(false)
 
   const videoPlayerRef = useRef(null)
+  const videoContainerRef = React.useRef(null)
   const [alert, setAlert] = React.useState({ open: false })
+  
+  React.useEffect(() => {
+    const container = videoContainerRef.current
+    if (!container) return
+
+    const aspectRatio = (details?.info?.width && details?.info?.height)
+      ? details.info.width / details.info.height
+      : 16 / 9
+
+    const computeSize = () => {
+      const availW = container.clientWidth
+      const availH = container.clientHeight
+      if (availW <= 0 || availH <= 0) return
+
+      let w = availW
+      let h = w / aspectRatio
+
+      if (h > availH) {
+        h = availH
+        w = h * aspectRatio
+      }
+    }
+
+    const observer = new ResizeObserver(computeSize)
+    observer.observe(container)
+
+    return () => observer.disconnect()
+  }, [details?.info?.width, details?.info?.height])
 
   React.useEffect(() => {
     async function fetch() {
@@ -85,8 +114,6 @@ const Watch = ({ authenticated }) => {
       VideoService.addView(id).catch((err) => console.error(err))
     }
   }
-
-
 
   const getPosterUrl = () => {
     if (SERVED_BY === 'nginx') {
@@ -191,23 +218,8 @@ const Watch = ({ authenticated }) => {
         <meta property="og:video:height" value={details?.info?.height} />
         <meta property="og:site_name" value="Fireshare" />
       </Helmet>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          maxHeight: 'calc(100vh - 64px)',
-          overflow: 'hidden',
-        }}
-      >
-        <Box
-          sx={{
-            width: '100%',
-            maxWidth: 'min(calc((100vh - 64px - 120px) * 16 / 9), 100vw)',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
+      <div style={{ display: 'flex', height: '100%', flexDirection: 'column', alignItems: 'start' }}>
+        <div ref={videoContainerRef} style={{ flex: '1 1 auto', minHeight: 0, width: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center', paddingLeft: 8, paddingRight: 8 }}>
           <VideoJSPlayer
             sources={getVideoSources(id, details?.info, details?.extension || '.mp4')}
             poster={getPosterUrl()}
@@ -219,39 +231,41 @@ const Watch = ({ authenticated }) => {
             }}
             startTime={time ? parseFloat(time) : 0}
             style={{ backgroundColor: '#000' }}
+            fluid={false}
+            fill={true}
           />
-          <Paper width="100%" square sx={{ p: 1, background: 'rgba(0, 0, 0, 0.1)' }}>
-            <Box sx={{ display: { xs: 'none', sm: 'flex' }, mr: 1 }}>
-              <Grid container spacing={1}>
-                <Grid item xs={12}>
-                  {controls()}
-                </Grid>
-                {details?.info?.description && (
-                  <Grid item xs={12}>
-                    <Paper sx={{ width: '100%', p: 2, background: 'rgba(255, 255, 255, 0.12)' }}>
-                      <Typography variant="subtitle2">{details?.info?.description}</Typography>
-                    </Paper>
-                  </Grid>
-                )}
+        </div>
+        <Paper square sx={{ p: 1, background: 'rgba(0, 0, 0, 0.1)', width: '100%' }}>
+          <Box sx={{ display: { xs: 'none', sm: 'flex' }, mr: 1 }}>
+            <Grid container spacing={1}>
+              <Grid item xs={12}>
+                {controls()}
               </Grid>
-            </Box>
-            <Box sx={{ display: { xs: 'flex', sm: 'none' } }}>
-              <Grid container spacing={1}>
+              {details?.info?.description && (
                 <Grid item xs={12}>
-                  {controls()}
+                  <Paper sx={{ width: '100%', p: 2, background: 'rgba(255, 255, 255, 0.12)' }}>
+                    <Typography variant="subtitle2">{details?.info?.description}</Typography>
+                  </Paper>
                 </Grid>
-                {details?.info?.description && (
-                  <Grid item xs={12}>
-                    <Paper sx={{ width: '100%', p: 2, background: 'rgba(255, 255, 255, 0.12)' }}>
-                      <Typography variant="subtitle2">{details?.info?.description}</Typography>
-                    </Paper>
-                  </Grid>
-                )}
+              )}
+            </Grid>
+          </Box>
+          <Box sx={{ display: { xs: 'flex', sm: 'none' } }}>
+            <Grid container spacing={1}>
+              <Grid item xs={12}>
+                {controls()}
               </Grid>
-            </Box>
-          </Paper>
-        </Box>
-      </Box>
+              {details?.info?.description && (
+                <Grid item xs={12}>
+                  <Paper sx={{ width: '100%', p: 2, background: 'rgba(255, 255, 255, 0.12)' }}>
+                    <Typography variant="subtitle2">{details?.info?.description}</Typography>
+                  </Paper>
+                </Grid>
+              )}
+            </Grid>
+          </Box>
+        </Paper>
+      </div>
     </>
   )
 }


### PR DESCRIPTION
Depending on the aspect ratio and/or the resolution of the video. The player would sometimes push the fireshare controls out of view. 

This solves that problem by dynamically calculating the maximum width and height the video player should be without pushing the fireshare controls outside of the browser window. 

This change has been added to both the /w/ page and the video modal. 