### PR TITLE
Make chown error in entrypoint.sh non-fatal

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,9 +14,9 @@ groupmod -o -g "$PGID" appuser
 usermod -o -u "$PUID" appuser
 
 # Set ownership of directories
-chown -R appuser:appuser $DATA_DIRECTORY
-chown -R appuser:appuser $VIDEO_DIRECTORY
-chown -R appuser:appuser $PROCESSED_DIRECTORY
+chown -R appuser:appuser $DATA_DIRECTORY || >&2 echo "WARNING: Could not chown the data directory ($DATA_DIRECTORY) to $PUID:$PGID. Make sure the container has permissions to access this directory."
+chown -R appuser:appuser $VIDEO_DIRECTORY || >&2 echo "WARNING: Could not chown the video directory ($DATA_DIRECTORY) to $PUID:$PGID. Make sure the container has permissions to access this directory."
+chown -R appuser:appuser $PROCESSED_DIRECTORY || >&2 echo "WARNING: Could not chown the processed directory ($DATA_DIRECTORY) to $PUID:$PGID. Make sure the container has permissions to access this directory."
 
 echo '-------------------------------------'
 echo "User uid:      $(id -u appuser)"


### PR DESCRIPTION
Fixes #455 

The simplest approach of fixing it, which is to print a warning to let the user know now it's on them to ensure the folder is readable. Fixes a regression from former versions, where chowning was non-fatal and that worked just fine, even with read-only directories.