### PR TITLE
Add og:description tag

### DIFF
--- a/app/client/src/views/Watch.js
+++ b/app/client/src/views/Watch.js
@@ -173,6 +173,7 @@ const Watch = ({ authenticated }) => {
         <meta property="og:type" value="video" />
         <meta property="og:url" value={window.location.href} />
         <meta property="og:title" value={details?.info?.title} />
+        <meta property="og:description" value={details?.info?.description} />
         <meta
           property="og:image"
           value={

--- a/app/server/fireshare/templates/metadata.html
+++ b/app/server/fireshare/templates/metadata.html
@@ -13,7 +13,7 @@
     <meta name="theme-color" content="#ffffff">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="#000000">
-    <meta name="description" content="{{ video.info.description or 'Self host your media and share with unique links.' }}">
+    <meta name="description" content="{{ video.info.description or 'Self-host your media and share with unique links.' }}">
     <link rel="apple-touch-icon" href="/logo192.png">
     <link rel="manifest" href="/manifest.json">
     <meta property="og:type" content="video" data-react-helmet="true">
@@ -23,6 +23,7 @@
     <meta property="og:video:secure_url" content="{{ domain }}/_content/video/{{ video.video_id }}{{ video.extension }}" data-react-helmet="true">
     <meta property="og:site_name" content="Fireshare" data-react-helmet="true">
     <meta property="og:title" content="{{ video.info.title }}" data-react-helmet="true">
+    <meta property="og:description" content="{{ video.info.description }}" data-react-helmet="true">
     <meta property="og:video:width" content="{{ video.info.width }}" data-react-helmet="true">
     <meta property="og:video:height" content="{{ video.info.height }}" data-react-helmet="true">
     <link itemprop="thumbnailUrl" href="{{ domain }}/_content/derived/{{ video.video_id }}/poster.jpg">


### PR DESCRIPTION
Currently Discord doesn't display the video title at all without it.

For `meta name="description"` I changed "Self hosted" to "Self-hosted" (cosmetic stylistic correction). But I am not adding this placeholder text fallback to og:description on the other hand, as I wouldn't want that to display as a placeholder, it would make things more cluttered compared to having just the video title and "Fireshare" above that.