### PR TITLE
cosmetic: decapitalize views count text + make video title not uppercase

### DIFF
--- a/app/client/src/components/admin/CompactVideoCard.js
+++ b/app/client/src/components/admin/CompactVideoCard.js
@@ -419,7 +419,7 @@ const CompactVideoCard = ({
                   borderRadius: '4px',
                 }}
               >
-                {`${video.view_count} ${video.view_count === 1 ? 'View' : 'Views'}`}
+                {`${video.view_count} ${video.view_count === 1 ? 'view' : 'views'}`}
               </Typography>
             </Box>
           </div>

--- a/app/client/src/components/admin/VideoListItem.js
+++ b/app/client/src/components/admin/VideoListItem.js
@@ -203,7 +203,7 @@ const VideoListItem = ({ video, openVideoHandler, alertHandler, authenticated, d
               </Grid>
               <Grid item sx={{ pl: 1, pr: 1 }}>
                 <Typography sx={{ fontWeight: 400, fontSize: 20, fontFamily: 'monospace' }}>
-                  {`${video.view_count} ${video.view_count === 1 ? 'View' : 'Views'}`}
+                  {`${video.view_count} ${video.view_count === 1 ? 'view' : 'views'}`}
                 </Typography>
               </Grid>
               <Grid item sx={{ pl: 1, pr: 1 }}>

--- a/app/client/src/views/Watch.js
+++ b/app/client/src/views/Watch.js
@@ -134,7 +134,7 @@ const Watch = ({ authenticated }) => {
               textOverflow: 'ellipsis',
             }}
           >
-            {`${views} ${views === 1 ? 'View' : 'Views'}`}
+            {`${views} ${views === 1 ? 'view' : 'views'}`}
           </div>
         </Button>
         <Button
@@ -150,7 +150,6 @@ const Watch = ({ authenticated }) => {
             style={{
               overflow: 'hidden',
               color: 'white',
-              textTransform: 'uppercase',
               whiteSpace: 'nowrap',
               textOverflow: 'ellipsis',
             }}


### PR DESCRIPTION
1. I think upper-casing video title can make manually-entered titles look awkward, e.g. instead of "He tried to hide xd" it's suddenly "HE TRIED TO HIDE XD". It makes it seem like the user upper-cased the title, and that implies, in this case, that they thought the video was way funnier than it actually was. The titles aren't capitalized on the regular video views, so it's not consistent either, and so this capitalization might catch someone off-guard if they share the copied sharing link somewhere without first checking how that page looks like.
2. I think saying "9 views" instead of "9 Views" makes it look much more readable, as the upper-case "V" doesn't compete for the height with the number. Stylistically it's not proper to capitalize something that serves as a unit of something either imo...