### PR TITLE
Add Progress Bar to Transcoding Progress, Much more reliable scanning and transcoding progress

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.8.1",
         "@silvermine/videojs-quality-selector": "^1.3.1",
         "axios": "^0.27.2",
+        "framer-motion": "^12.34.3",
         "lodash": "^4.17.21",
         "react": "^18.1.0",
         "react-copy-to-clipboard": "^5.1.0",
@@ -8852,6 +8853,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
+      "integrity": "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.3",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -11995,6 +12023,21 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
+      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/mpd-parser": {
       "version": "1.3.1",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -10,6 +10,7 @@
     "@mui/material": "^5.8.1",
     "@silvermine/videojs-quality-selector": "^1.3.1",
     "axios": "^0.27.2",
+    "framer-motion": "^12.34.3",
     "lodash": "^4.17.21",
     "react": "^18.1.0",
     "react-copy-to-clipboard": "^5.1.0",

--- a/app/client/src/components/nav/FolderSuggestionInline.js
+++ b/app/client/src/components/nav/FolderSuggestionInline.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Box, Typography, IconButton, CircularProgress, Tooltip } from '@mui/material'
 import CheckIcon from '@mui/icons-material/Check'
 import CloseIcon from '@mui/icons-material/Close'
-import SportsEsportsIcon from '@mui/icons-material/SportsEsports'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import { GameService } from '../../services'
 

--- a/app/client/src/components/nav/TranscodingStatus.js
+++ b/app/client/src/components/nav/TranscodingStatus.js
@@ -6,6 +6,39 @@ import { motion } from 'framer-motion'
 import adminSSE from '../../services/AdminSSE'
 import SyncIcon from '@mui/icons-material/Sync'
 
+const formatEta = (seconds) => {
+  if (!seconds || seconds < 0) return null
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  if (mins > 0) return `${mins}m ${secs}s left`
+  return `${secs}s left`
+}
+
+const styles = {
+  card: {
+    m: 1,
+    border: '1px solid rgba(194, 224, 255, 0.18)',
+    borderRadius: '8px',
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor: 'transparent',
+    ':hover': { backgroundColor: 'rgba(194, 224, 255, 0.08)' },
+  },
+  cardExpanded: { width: 222, px: 2, py: 1.5 },
+  cardCollapsed: { width: 42, height: 40, justifyContent: 'center' },
+  textPrimary: { fontFamily: 'monospace', fontWeight: 600, fontSize: 12, color: '#EBEBEB' },
+  textSecondary: { fontFamily: 'monospace', fontSize: 10, color: '#999' },
+  textAccent: { color: '#2684FF' },
+  truncate: { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' },
+  progressTrack: {
+    width: '100%',
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(194, 224, 255, 0.1)',
+    overflow: 'hidden',
+  },
+}
+
 const TranscodingStatus = ({ open }) => {
   const [status, setStatus] = React.useState(null)
   const [stoppedMessage, setStoppedMessage] = React.useState(null)
@@ -32,137 +65,71 @@ const TranscodingStatus = ({ open }) => {
 
   if (stoppedMessage && open) {
     return (
-      <>
-        <Box
-          sx={{
-            width: 222,
-            m: 1,
-            px: 2,
-            py: 1.5,
-            border: '1px solid rgba(194, 224, 255, 0.18)',
-            borderRadius: '8px',
-            display: 'flex',
-            alignItems: 'center',
-            color: '#EBEBEB',
-            fontWeight: 600,
-            fontSize: 13,
-            backgroundColor: 'transparent',
-            ':hover': {
-              backgroundColor: 'rgba(194, 224, 255, 0.08)',
-            },
-          }}
-        >
-          <Grid container alignItems="center">
-            <Grid item>
-              <Typography
-                sx={{
-                  fontFamily: 'monospace',
-                  fontWeight: 600,
-                  fontSize: 12,
-                  color: '#EBEBEB',
-                }}
-              >
-                {stoppedMessage}
-              </Typography>
-            </Grid>
+      <Box sx={{ ...styles.card, ...styles.cardExpanded }}>
+        <Grid container alignItems="center">
+          <Grid item>
+            <Typography sx={styles.textPrimary}>
+              {stoppedMessage}
+            </Typography>
           </Grid>
-        </Box>
-      </>
+        </Grid>
+      </Box>
     )
   }
 
   if (open) {
     return (
-      <>
-        <Tooltip title={status.current_video || 'Not transcoding'} arrow placement="right">
-          <Box
-            sx={{
-              width: 222,
-              m: 1,
-              px: 2,
-              py: 1.5,
-              border: '1px solid rgba(194, 224, 255, 0.18)',
-              borderRadius: '8px',
-              display: 'flex',
-              alignItems: 'center',
-              color: '#EBEBEB',
-              fontWeight: 600,
-              fontSize: 13,
-              backgroundColor: 'transparent',
-              ':hover': {
-                backgroundColor: 'rgba(194, 224, 255, 0.08)',
-              },
-            }}
-          >
-            <Grid container alignItems="center">
-              <Grid item sx={{
-                overflow: 'hidden'
-              }}>
-                <Typography
-                  sx={{
-                    fontFamily: 'monospace',
-                    fontWeight: 600,
-                    fontSize: 12,
-                    color: '#EBEBEB',
-                  }}
-                >
-                  {status.total === 0 ? (
-                    'Preparing transcode...'
-                  ) : (
-                    <>
-                      Transcoding:{' '}
-                      <Box component="span" sx={{ color: '#2684FF' }}>
-                        {status.current}/{status.total}
-                      </Box>
-                    </>
-                  )}
-                </Typography>
-                {status.current_video && (
-                  <Typography
-                    sx={{
-                      fontFamily: 'monospace',
-                      fontSize: 10,
-                      color: '#999',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
-                    {status.current_video}
-                  </Typography>
-                )}
-                {typeof status.percent === 'number' && (
-                  <Box sx={{ mt: 1, width: '100%' }}>
-                    <Box
-                      sx={{
-                        width: '100%',
-                        height: 4,
-                        borderRadius: 2,
-                        backgroundColor: 'rgba(194, 224, 255, 0.1)',
-                        overflow: 'hidden',
-                      }}
-                    >
-                      <motion.div
-                        initial={{ width: 0 }}
-                        animate={{ width: `${status.percent}%` }}
-                        transition={{ duration: 0.6, ease: [0.25, 0.1, 0.25, 1] }}
-                        style={{
-                          height: '100%',
-                          backgroundColor: '#2684FF',
-                          borderRadius: 4,
-                        }}
-                      />
+      <Tooltip title={status.current_video || 'Not transcoding'} arrow placement="right">
+        <Box sx={{ ...styles.card, ...styles.cardExpanded }}>
+          <Grid container alignItems="center">
+            <Grid item sx={{ overflow: 'hidden' }}>
+              <Typography sx={styles.textPrimary}>
+                {status.total === 0 ? (
+                  'Preparing transcode...'
+                ) : (
+                  <>
+                    Transcoding:{' '}
+                    <Box component="span" sx={styles.textAccent}>
+                      {status.current}/{status.total}
                     </Box>
-                    <Typography sx={{ fontSize: 10, color: '#999', mt: 0.5 }}>
-                      {status.percent.toFixed(0)}%{status.speed ? ` • ${status.speed}x` : ''}
-                    </Typography>
-                  </Box>
+                  </>
                 )}
-              </Grid>
+              </Typography>
+              {status.current_video && (
+                <Typography sx={{ ...styles.textSecondary, ...styles.truncate }}>
+                  {status.current_video}
+                </Typography>
+              )}
+              {typeof status.percent === 'number' && (
+                <Box sx={{ mt: 1, width: '100%' }}>
+                  <Box sx={styles.progressTrack}>
+                    <motion.div
+                      initial={{ width: 0 }}
+                      animate={{ width: `${status.percent}%` }}
+                      transition={{ duration: 0.6, ease: [0.25, 0.1, 0.25, 1] }}
+                      style={{
+                        height: '100%',
+                        backgroundColor: '#2684FF',
+                        borderRadius: 4,
+                      }}
+                    />
+                  </Box>
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 0.5 }}>
+                    <Typography sx={styles.textSecondary}>
+                      {status.percent.toFixed(0)}%{status.eta_seconds ? ` • ${formatEta(status.eta_seconds)}` : ''}
+                    </Typography>
+                    {status.resolution && (
+                      <Typography sx={{ ...styles.textSecondary, ...styles.textAccent, fontWeight: 600 }}>
+                        {status.resolution}
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              )}
             </Grid>
-          </Box>
-        </Tooltip >
-      </>
+          </Grid>
+        </Box>
+      </Tooltip>
     )
   }
 
@@ -171,45 +138,20 @@ const TranscodingStatus = ({ open }) => {
     : `Transcoding: ${status.current}/${status.total}${status.current_video ? `\n${status.current_video}` : ''}`
 
   return (
-    <>
-      <Tooltip title={tooltipText} arrow placement="right">
-        <Box
-          sx={{
-            width: 42,
-            m: 1,
-            height: 40,
-            border: '1px solid rgba(194, 224, 255, 0.18)',
-            borderRadius: '8px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            ':hover': {
-              backgroundColor: 'rgba(194, 224, 255, 0.08)',
+    <Tooltip title={tooltipText} arrow placement="right">
+      <Box sx={{ ...styles.card, ...styles.cardCollapsed }}>
+        <IconButton sx={{ p: 0.5, pointerEvents: 'all' }}>
+          <SyncIcon sx={{
+            color: '#EBEBEB',
+            animation: 'spin 1.5s linear infinite',
+            '@keyframes spin': {
+              '0%': { transform: 'rotate(360deg)' },
+              '100%': { transform: 'rotate(0deg)' },
             },
-          }}
-        >
-          <Typography
-            sx={{
-              fontFamily: 'monospace',
-              fontWeight: 600,
-              fontSize: 15,
-              color: '#EBEBEB',
-            }}
-          >
-            <IconButton sx={{ p: 0.5, pointerEvents: 'all' }}>
-              <SyncIcon sx={{
-                color: '#EBEBEB',
-                animation: 'spin 1.5s linear infinite',
-                '@keyframes spin': {
-                  '0%': { transform: 'rotate(360deg)' },
-                  '100%': { transform: 'rotate(0deg)' },
-                },
-              }} />
-            </IconButton>
-          </Typography>
-        </Box>
-      </Tooltip>
-    </>
+          }} />
+        </IconButton>
+      </Box>
+    </Tooltip>
   )
 }
 

--- a/app/client/src/components/nav/TranscodingStatus.js
+++ b/app/client/src/components/nav/TranscodingStatus.js
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Grid, Box, IconButton } from '@mui/material'
 import Typography from '@mui/material/Typography'
 import Tooltip from '@mui/material/Tooltip'
+import { motion } from 'framer-motion'
 import adminSSE from '../../services/AdminSSE'
 import SyncIcon from '@mui/icons-material/Sync'
 
@@ -117,7 +118,6 @@ const TranscodingStatus = ({ open }) => {
                   )}
                 </Typography>
                 {status.current_video && (
-
                   <Typography
                     sx={{
                       fontFamily: 'monospace',
@@ -130,6 +130,33 @@ const TranscodingStatus = ({ open }) => {
                   >
                     {status.current_video}
                   </Typography>
+                )}
+                {typeof status.percent === 'number' && (
+                  <Box sx={{ mt: 1, width: '100%' }}>
+                    <Box
+                      sx={{
+                        width: '100%',
+                        height: 4,
+                        borderRadius: 2,
+                        backgroundColor: 'rgba(194, 224, 255, 0.1)',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <motion.div
+                        initial={{ width: 0 }}
+                        animate={{ width: `${status.percent}%` }}
+                        transition={{ duration: 0.6, ease: [0.25, 0.1, 0.25, 1] }}
+                        style={{
+                          height: '100%',
+                          backgroundColor: '#2684FF',
+                          borderRadius: 4,
+                        }}
+                      />
+                    </Box>
+                    <Typography sx={{ fontSize: 10, color: '#999', mt: 0.5 }}>
+                      {status.percent.toFixed(0)}%{status.speed ? ` • ${status.speed}x` : ''}
+                    </Typography>
+                  </Box>
                 )}
               </Grid>
             </Grid>

--- a/app/client/src/services/AdminSSE.js
+++ b/app/client/src/services/AdminSSE.js
@@ -51,4 +51,6 @@ class AdminSSEManager {
   }
 }
 
-export default new AdminSSEManager()
+const adminSSE = new AdminSSEManager()
+
+export default adminSSE

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -472,22 +472,25 @@ def cancel_transcoding():
     if pid_to_kill is None:
         status = util.read_transcoding_status(paths['data'])
         pid_to_kill = status.get('pid')
-        if pid_to_kill is None or not status.get('is_running', False):
+        # If status doesn't show running, nothing to cancel
+        if not status.get('is_running', False):
             return Response(status=400, response='No transcoding in progress')
 
-    try:
-        # Kill the entire process group (including ffmpeg child processes)
-        os.killpg(os.getpgid(pid_to_kill), signal.SIGTERM)
-        if _transcoding_process is not None:
-            _transcoding_process.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        os.killpg(os.getpgid(pid_to_kill), signal.SIGKILL)
-    except ProcessLookupError:
-        pass  # Process already dead
-    except OSError:
-        pass  # Process group doesn't exist
+    # Try to kill the process if we have a PID
+    if pid_to_kill is not None:
+        try:
+            # Kill the entire process group (including ffmpeg child processes)
+            os.killpg(os.getpgid(pid_to_kill), signal.SIGTERM)
+            if _transcoding_process is not None:
+                _transcoding_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(os.getpgid(pid_to_kill), signal.SIGKILL)
+        except ProcessLookupError:
+            pass  # Process already dead
+        except OSError:
+            pass  # Process group doesn't exist
 
-    # Clear the status file
+    # Always clear the status file when cancel is requested
     util.clear_transcoding_status(paths['data'])
 
     _transcoding_process = None

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -344,7 +344,8 @@ def get_transcoding_status():
         "total": progress.get('total', 0),
         "current_video": progress.get('current_video'),
         "percent": progress.get('percent'),
-        "speed": progress.get('speed')
+        "eta_seconds": progress.get('eta_seconds'),
+        "resolution": progress.get('resolution')
     })
 
 
@@ -386,7 +387,8 @@ def admin_event_stream():
                     "total": progress.get('total', 0),
                     "current_video": progress.get('current_video'),
                     "percent": progress.get('percent'),
-                    "speed": progress.get('speed')
+                    "eta_seconds": progress.get('eta_seconds'),
+                    "resolution": progress.get('resolution')
                 }
 
                 if transcoding_state != last_transcoding_state:

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -342,7 +342,9 @@ def get_transcoding_status():
         "is_running": is_running,
         "current": progress.get('current', 0),
         "total": progress.get('total', 0),
-        "current_video": progress.get('current_video')
+        "current_video": progress.get('current_video'),
+        "percent": progress.get('percent'),
+        "speed": progress.get('speed')
     })
 
 
@@ -382,7 +384,9 @@ def admin_event_stream():
                     "is_running": is_running,
                     "current": progress.get('current', 0),
                     "total": progress.get('total', 0),
-                    "current_video": progress.get('current_video')
+                    "current_video": progress.get('current_video'),
+                    "percent": progress.get('percent'),
+                    "speed": progress.get('speed')
                 }
 
                 if transcoding_state != last_transcoding_state:
@@ -479,12 +483,23 @@ def cancel_transcoding():
     # Try to kill the process if we have a PID
     if pid_to_kill is not None:
         try:
-            # Kill the entire process group (including ffmpeg child processes)
-            os.killpg(os.getpgid(pid_to_kill), signal.SIGTERM)
+            target_pgid = os.getpgid(pid_to_kill)
+            my_pgid = os.getpgid(os.getpid())
+
+            if target_pgid != my_pgid:
+                # Safe to kill the process group (won't kill Flask)
+                os.killpg(target_pgid, signal.SIGTERM)
+            else:
+                # Same process group as Flask - only kill the specific process
+                os.kill(pid_to_kill, signal.SIGTERM)
+
             if _transcoding_process is not None:
                 _transcoding_process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            os.killpg(os.getpgid(pid_to_kill), signal.SIGKILL)
+            if target_pgid != my_pgid:
+                os.killpg(target_pgid, signal.SIGKILL)
+            else:
+                os.kill(pid_to_kill, signal.SIGKILL)
         except ProcessLookupError:
             pass  # Process already dead
         except OSError:
@@ -649,7 +664,7 @@ def reset_database():
 @login_required
 def manual_scan():
     current_app.logger.info(f"Executed manual scan")
-    Popen(["fireshare", "bulk-import"], shell=False)
+    Popen(["fireshare", "bulk-import"], shell=False, start_new_session=True)
     return Response(status=200)
 
 @api.route('/api/manual/scan-dates')
@@ -1289,7 +1304,7 @@ def _launch_scan_video(save_path, config):
     Launch scan-video and publish an initial transcoding-running status when
     auto-transcode is enabled so SSE subscribers can reflect upload-triggered work.
     """
-    scan_proc = Popen(["fireshare", "scan-video", f"--path={save_path}"], shell=False)
+    scan_proc = Popen(["fireshare", "scan-video", f"--path={save_path}"], shell=False, start_new_session=True)
 
     transcoding_enabled = current_app.config.get('ENABLE_TRANSCODING', False)
     auto_transcode = config.get('transcoding', {}).get('auto_transcode', True)

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -1306,14 +1306,27 @@ def _launch_scan_video(save_path, config):
     Launch scan-video and publish an initial transcoding-running status when
     auto-transcode is enabled so SSE subscribers can reflect upload-triggered work.
     """
+    paths = current_app.config['PATHS']
+    data_path = paths['data']
     scan_proc = Popen(["fireshare", "scan-video", f"--path={save_path}"], shell=False, start_new_session=True)
+
+    def reap_and_cleanup():
+        try:
+            scan_proc.wait()
+            status = util.read_transcoding_status(data_path)
+            # Clear stale placeholder/status written for this upload process.
+            if status.get('pid') == scan_proc.pid:
+                util.clear_transcoding_status(data_path)
+        except Exception as e:
+            logger.debug(f"Scan process cleanup skipped: {e}")
+
+    threading.Thread(target=reap_and_cleanup, daemon=True).start()
 
     transcoding_enabled = current_app.config.get('ENABLE_TRANSCODING', False)
     auto_transcode = config.get('transcoding', {}).get('auto_transcode', True)
     if transcoding_enabled and auto_transcode:
         try:
-            paths = current_app.config['PATHS']
-            util.write_transcoding_status(paths['data'], 0, 0, None, scan_proc.pid)
+            util.write_transcoding_status(data_path, 0, 0, None, scan_proc.pid)
         except Exception as e:
             logger.warning(f"Failed to write initial upload transcoding status: {e}")
 

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -456,7 +456,7 @@ def scan_video(ctx, path):
                 if video_path.exists():
                     
                     poster_path = Path(derived_path, "poster.jpg")
-                    should_create_poster = (not poster_path.exists() or regenerate)
+                    should_create_poster = not poster_path.exists()
                     if should_create_poster:
                         if not derived_path.exists():
                             derived_path.mkdir(parents=True)
@@ -718,6 +718,7 @@ def transcode_videos(regenerate, video, include_corrupt):
 
         if total_jobs == 0:
             logger.info("No videos need transcoding")
+            util.clear_transcoding_status(paths['data'])
             return
 
         # Write initial transcoding status with our PID so the API can track us

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -688,7 +688,7 @@ def transcode_videos(regenerate, video, include_corrupt):
 
         # Get videos to transcode
         vinfos = VideoInfo.query.filter(VideoInfo.video_id==video).all() if video else VideoInfo.query.all()
-        
+
         # Filter out corrupt videos unless explicitly included
         corrupt_videos = set(get_all_corrupt_videos())
         if not include_corrupt and not video:
@@ -697,62 +697,64 @@ def transcode_videos(regenerate, video, include_corrupt):
             skipped_count = original_count - len(vinfos)
             if skipped_count > 0:
                 logger.info(f"Skipping {skipped_count} video(s) previously marked as corrupt. Use --include-corrupt to retry them.")
-        
-        total_videos = len(vinfos)
-        logger.info(f'Processing {total_videos:,} videos for transcoding (GPU: {use_gpu}, Encoder: {encoder_preference})')
 
-        # Write initial transcoding status with our PID so the API can track us
-        util.write_transcoding_status(paths['data'], 0, total_videos, pid=os.getpid())
-
-        for idx, vi in enumerate(vinfos, 1):
-            # Update transcoding progress with the video title
-            util.write_transcoding_status(paths['data'], idx, total_videos, vi.title)
-            derived_path = Path(processed_root, "derived", vi.video_id)
+        # Build work queue: list of (video_info, height) tuples that actually need transcoding
+        work_items = []
+        for vi in vinfos:
             video_path = Path(processed_root, "video_links", vi.video_id + vi.video.extension)
-            
             if not video_path.exists():
-                logger.warning(f"Skipping transcoding for video {vi.video_id} because the video at {str(video_path)} does not exist")
                 continue
-            
-            if not derived_path.exists():
-                derived_path.mkdir(parents=True)
-            
-            # Transcode to each enabled resolution
+            derived_path = Path(processed_root, "derived", vi.video_id)
             original_height = vi.height or 0
-            video_is_corrupt = False
-
             for height in resolutions:
-                if video_is_corrupt:
-                    break
-
                 if original_height <= height:
                     continue
-
                 transcode_path = derived_path / f"{vi.video_id}-{height}p.mp4"
-                has_attr = f'has_{height}p'
-
                 if not transcode_path.exists() or regenerate:
-                    logger.info(f"[{idx}/{total_videos}] Transcoding {vi.video_id} to {height}p ({vi.video.path})")
-                    success, failure_reason = util.transcode_video_quality(
-                        video_path, transcode_path, height, use_gpu, None, encoder_preference
-                    )
-                    if success:
-                        setattr(vi, has_attr, True)
-                        if is_video_corrupt(vi.video_id):
-                            clear_video_corrupt(vi.video_id)
-                        db.session.add(vi)
-                        db.session.commit()
-                    elif failure_reason == 'corruption':
-                        logger.warning(f"Skipping video {vi.video_id} {height}p transcode - source file appears corrupt")
-                        mark_video_corrupt(vi.video_id)
-                        video_is_corrupt = True
-                    else:
-                        logger.warning(f"Skipping video {vi.video_id} {height}p transcode - all encoders failed")
-                elif transcode_path.exists():
-                    logger.debug(f"Skipping {height}p transcode for {vi.video_id} (already exists)")
-                    setattr(vi, has_attr, True)
-                    db.session.add(vi)
-                    db.session.commit()
+                    work_items.append((vi, height, video_path, derived_path, transcode_path))
+
+        total_jobs = len(work_items)
+        logger.info(f'Processing {total_jobs:,} transcode job(s) (GPU: {use_gpu}, Encoder: {encoder_preference})')
+
+        if total_jobs == 0:
+            logger.info("No videos need transcoding")
+            return
+
+        # Write initial transcoding status with our PID so the API can track us
+        util.write_transcoding_status(paths['data'], 0, total_jobs, pid=os.getpid())
+
+        # Track corrupt videos to skip remaining heights for that video
+        corrupt_video_ids = set()
+
+        for idx, (vi, height, video_path, derived_path, transcode_path) in enumerate(work_items, 1):
+            # Skip if this video was marked corrupt during this run
+            if vi.video_id in corrupt_video_ids:
+                continue
+
+            # Update transcoding progress
+            util.write_transcoding_status(paths['data'], idx, total_jobs, f"{vi.title} ({height}p)")
+
+            if not derived_path.exists():
+                derived_path.mkdir(parents=True)
+
+            has_attr = f'has_{height}p'
+
+            logger.info(f"[{idx}/{total_jobs}] Transcoding {vi.video_id} to {height}p ({vi.video.path})")
+            success, failure_reason = util.transcode_video_quality(
+                video_path, transcode_path, height, use_gpu, None, encoder_preference
+            )
+            if success:
+                setattr(vi, has_attr, True)
+                if is_video_corrupt(vi.video_id):
+                    clear_video_corrupt(vi.video_id)
+                db.session.add(vi)
+                db.session.commit()
+            elif failure_reason == 'corruption':
+                logger.warning(f"Skipping video {vi.video_id} {height}p transcode - source file appears corrupt")
+                mark_video_corrupt(vi.video_id)
+                corrupt_video_ids.add(vi.video_id)
+            else:
+                logger.warning(f"Skipping video {vi.video_id} {height}p transcode - all encoders failed")
 
         util.clear_transcoding_status(paths['data'])
         logger.info("Transcoding complete")

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -732,7 +732,7 @@ def transcode_videos(regenerate, video, include_corrupt):
                 continue
 
             # Update transcoding progress
-            util.write_transcoding_status(paths['data'], idx, total_jobs, f"{vi.title} ({height}p)")
+            util.write_transcoding_status(paths['data'], idx, total_jobs, vi.title, resolution=f"{height}p")
 
             if not derived_path.exists():
                 derived_path.mkdir(parents=True)

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -741,7 +741,8 @@ def transcode_videos(regenerate, video, include_corrupt):
 
             logger.info(f"[{idx}/{total_jobs}] Transcoding {vi.video_id} to {height}p ({vi.video.path})")
             success, failure_reason = util.transcode_video_quality(
-                video_path, transcode_path, height, use_gpu, None, encoder_preference
+                video_path, transcode_path, height, use_gpu, None, encoder_preference,
+                data_path=paths['data']
             )
             if success:
                 setattr(vi, has_attr, True)

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -77,12 +77,13 @@ def remove_lock(path: Path):
 # Transcoding status file functions
 TRANSCODING_STATUS_FILE = "transcoding_status.json"
 
-def write_transcoding_status(data_path: Path, current: int, total: int, current_video: str = None, pid: int = None, percent: float = None, speed: float = None):
+def write_transcoding_status(data_path: Path, current: int, total: int, current_video: str = None, pid: int = None, percent: float = None, eta_seconds: float = None, resolution: str = None):
     """
     Writes the current transcoding progress to a status file.
     Called by the CLI during transcoding to report progress.
     If pid is provided, it will be included. Otherwise, uses the current process PID.
-    percent and speed are optional per-video progress info from ffmpeg.
+    percent and eta_seconds are optional per-video progress info from ffmpeg.
+    resolution is the target resolution (e.g., "1080p").
     """
     status_file = data_path / TRANSCODING_STATUS_FILE
 
@@ -101,8 +102,10 @@ def write_transcoding_status(data_path: Path, current: int, total: int, current_
     # Include progress data if available
     if percent is not None:
         status["percent"] = round(percent, 1)
-    if speed is not None:
-        status["speed"] = round(speed, 2)
+    if eta_seconds is not None:
+        status["eta_seconds"] = round(eta_seconds)
+    if resolution is not None:
+        status["resolution"] = resolution
     tmp_file = status_file.with_suffix(f"{status_file.suffix}.tmp")
     try:
         with open(tmp_file, 'w') as f:
@@ -551,6 +554,7 @@ def run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds=None, data_pat
     last_update = 0
     speed = None
     percent = None
+    current_seconds = 0
 
     # -progress outputs clean key=value lines:
     # out_time_us=83450000
@@ -567,7 +571,8 @@ def run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds=None, data_pat
             if key == 'out_time_us' and total_duration:
                 try:
                     current_us = int(value)
-                    percent = min(100, (current_us / 1_000_000) / total_duration * 100)
+                    current_seconds = current_us / 1_000_000
+                    percent = min(100, (current_seconds / total_duration) * 100)
                 except ValueError:
                     pass
 
@@ -581,6 +586,12 @@ def run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds=None, data_pat
                 # 'continue' or 'end' - good time to update status
                 now = time.time()
                 if now - last_update >= 0.5 and data_path and percent is not None:
+                    # Calculate ETA: remaining time / encoding speed
+                    eta_seconds = None
+                    if speed and speed > 0 and total_duration:
+                        remaining_seconds = total_duration - current_seconds
+                        eta_seconds = remaining_seconds / speed
+
                     # Read existing status and update with progress
                     existing = read_transcoding_status(data_path)
                     write_transcoding_status(
@@ -590,7 +601,8 @@ def run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds=None, data_pat
                         existing.get('current_video'),
                         existing.get('pid'),
                         percent,
-                        speed
+                        eta_seconds,
+                        existing.get('resolution')
                     )
                     last_update = now
 

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -77,11 +77,12 @@ def remove_lock(path: Path):
 # Transcoding status file functions
 TRANSCODING_STATUS_FILE = "transcoding_status.json"
 
-def write_transcoding_status(data_path: Path, current: int, total: int, current_video: str = None, pid: int = None):
+def write_transcoding_status(data_path: Path, current: int, total: int, current_video: str = None, pid: int = None, percent: float = None, speed: float = None):
     """
     Writes the current transcoding progress to a status file.
     Called by the CLI during transcoding to report progress.
     If pid is provided, it will be included. Otherwise, uses the current process PID.
+    percent and speed are optional per-video progress info from ffmpeg.
     """
     status_file = data_path / TRANSCODING_STATUS_FILE
 
@@ -97,6 +98,11 @@ def write_transcoding_status(data_path: Path, current: int, total: int, current_
         "current_video": current_video,
         "pid": pid
     }
+    # Include progress data if available
+    if percent is not None:
+        status["percent"] = round(percent, 1)
+    if speed is not None:
+        status["speed"] = round(speed, 2)
     tmp_file = status_file.with_suffix(f"{status_file.suffix}.tmp")
     try:
         with open(tmp_file, 'w') as f:
@@ -531,9 +537,70 @@ def _get_encoder_candidates(use_gpu=False, encoder_preference='auto'):
             return [h264_nvenc, av1_nvenc, h264_cpu, av1_cpu]
         return [h264_cpu, av1_cpu]
 
-def run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds=None):
-    """Run an FFmpeg command with timeout support."""
-    return sp.run(cmd, timeout=timeout_seconds)
+def run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds=None, data_path=None):
+    """
+    Run an FFmpeg command with real-time progress tracking via -progress flag.
+
+    If data_path is provided, reads the existing status file and updates it with
+    percent/speed. Progress is throttled to every 0.5 seconds to avoid I/O overhead.
+    """
+    # Insert -progress pipe:1 before output file (last arg)
+    cmd_with_progress = cmd[:-1] + ['-progress', 'pipe:1'] + [cmd[-1]]
+
+    process = sp.Popen(cmd_with_progress, stdout=sp.PIPE, stderr=sp.PIPE, text=True)
+    last_update = 0
+    speed = None
+    percent = None
+
+    # -progress outputs clean key=value lines:
+    # out_time_us=83450000
+    # speed=1.5x
+    # progress=continue
+    try:
+        for line in process.stdout:
+            line = line.strip()
+            if '=' not in line:
+                continue
+
+            key, value = line.split('=', 1)
+
+            if key == 'out_time_us' and total_duration:
+                try:
+                    current_us = int(value)
+                    percent = min(100, (current_us / 1_000_000) / total_duration * 100)
+                except ValueError:
+                    pass
+
+            elif key == 'speed' and value.endswith('x'):
+                try:
+                    speed = float(value.rstrip('x'))
+                except ValueError:
+                    pass
+
+            elif key == 'progress':
+                # 'continue' or 'end' - good time to update status
+                now = time.time()
+                if now - last_update >= 0.5 and data_path and percent is not None:
+                    # Read existing status and update with progress
+                    existing = read_transcoding_status(data_path)
+                    write_transcoding_status(
+                        data_path,
+                        existing.get('current', 0),
+                        existing.get('total', 0),
+                        existing.get('current_video'),
+                        existing.get('pid'),
+                        percent,
+                        speed
+                    )
+                    last_update = now
+
+        process.wait(timeout=timeout_seconds)
+    except sp.TimeoutExpired:
+        process.kill()
+        process.wait()
+        raise
+
+    return process
 
 
 def _build_transcode_command(video_path, out_path, height, encoder):
@@ -550,7 +617,7 @@ def _build_transcode_command(video_path, out_path, height, encoder):
     
     return cmd
 
-def transcode_video_quality(video_path, out_path, height, use_gpu=False, timeout_seconds=None, encoder_preference='auto'):
+def transcode_video_quality(video_path, out_path, height, use_gpu=False, timeout_seconds=None, encoder_preference='auto', data_path=None):
     """
     Transcode a video to a specific height (e.g., 720, 1080) while maintaining aspect ratio.
     
@@ -613,7 +680,7 @@ def transcode_video_quality(video_path, out_path, height, use_gpu=False, timeout
         logger.debug(f"$: {' '.join(cmd)}")
 
         try:
-            result = run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds)
+            result = run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds, data_path)
             if result.returncode == 0:
                 e = time.time()
                 logger.info(f'Transcoded {str(out_path)} to {height}p in {e-s:.2f}s')
@@ -740,7 +807,7 @@ def transcode_video_quality(video_path, out_path, height, use_gpu=False, timeout
         logger.debug(f"$: {' '.join(cmd)}")
 
         try:
-            result = run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds)
+            result = run_ffmpeg_with_progress(cmd, total_duration, timeout_seconds, data_path)
             if result.returncode == 0:
                 # Success! Cache this encoder and return
                 logger.info(f"✓ {encoder['name']} works! Using it for all transcodes this session.")


### PR DESCRIPTION
I know we were discussing using ffmpeg to track progress to show on the frontend, and im happy to report I did it! This PR introduces a progress bar to `TranscodingStatus.js` , and a much cleaner work queue so transcoding progress is MUCH more reliable.

![Screen Recording 2026-02-20 at 6 59 42 PM 2026-02-20 20_33_39](https://github.com/user-attachments/assets/0c2d2ed2-cd0d-4067-833d-ab81388eebff)

• Used ffmpeg's -progress flag to export `percent`, `eta_seconds`, and `resolution` to `transcoding_status.json`
• Redid the transcoding workflow to only include clips that need to be transcoded. Previously it would report the clip number/total clips of the ENTIRE LIBRARY, which wasn't very useful. This has been fixed to only track a queue with clips with missing transcodes.
• Cleaned up redundant stylings in 'TranscodingStatus.js', resulting in a bunch of less code to maintain. 
• Added progress bar to 'TranscodingStatus.js'. This is using the `framer-motion` library to achieve the animations for the progress bar, it's really nice! And I hope to use the library more to improve the look of some components in the future. 'framer-motion' is super lightweight, and also open source so no issues using their library here.
• Moved transcode resolution from the file name, to the bottom right of the progress bar, to maintain better visibility. 

Overall super excited about this. Been testing it like crazy all day and I think it's ready to ship, but definitely excited to hear what you think!  