### PR TITLE
Fixed width issue of short file names in Transcoding Status, Corrected links for scheduled scans 

### DIFF
--- a/app/client/src/components/admin/UploadCard.js
+++ b/app/client/src/components/admin/UploadCard.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Box, Grid, Paper, Stack, Typography } from '@mui/material'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import styled from '@emotion/styled'
+import { motion } from 'framer-motion'
 import { VideoService } from '../../services'
 import { getSetting } from '../../common/utils'
 
@@ -17,29 +18,39 @@ const UploadCard = ({ authenticated, handleAlert, mini}) => {
   const [progress, setProgress] = React.useState(0)
   const [uploadRate, setUploadRate] = React.useState()
   const uiConfig = getSetting('ui_config')
+  const lastProgressUpdate = React.useRef(0)
 
   const changeHandler = (event) => {
     setProgress(0)
+    lastProgressUpdate.current = 0
     setSelectedFile(event.target.files[0])
     setIsSelected(true)
   }
 
   const uploadProgress = (progress, rate) => {
     if (progress <= 1 && progress >= 0) {
-      setProgress(progress)
-      setUploadRate((prev) => ({ ...rate }))
+      const now = Date.now()
+      if (progress === 1 || now - lastProgressUpdate.current >= 1000) {
+        lastProgressUpdate.current = now
+        setProgress(progress)
+        setUploadRate(() => ({ ...rate }))
+      }
     }
   }
 
   const uploadProgressChunked = (progress, progressTotal, rate) => {
+    const now = Date.now()
+    const stale = now - lastProgressUpdate.current >= 1000
     if (progressTotal <= 1 && progressTotal >= 0) {
-      setProgress(progressTotal);
-      setUploadRate((prev) => ({ ...rate }))
-    } else {
-      if (progress <= 1 && progress >= 0) {
-        setProgress(progress)
-        setUploadRate((prev) => ({ ...rate }))
+      if (progressTotal === 1 || stale) {
+        lastProgressUpdate.current = now
+        setProgress(progressTotal)
+        setUploadRate(() => ({ ...rate }))
       }
+    } else if (progress <= 1 && progress >= 0 && (progress === 1 || stale)) {
+      lastProgressUpdate.current = now
+      setProgress(progress)
+      setUploadRate(() => ({ ...rate }))
     }
   }
 
@@ -160,7 +171,7 @@ const UploadCard = ({ authenticated, handleAlert, mini}) => {
           sx={{
             position: 'relative',
             width: '100%',
-            height: '50px',
+            height: '64px',
             cursor: 'pointer',
             background: 'rgba(0,0,0,0)',
             overflow: 'hidden',
@@ -169,8 +180,8 @@ const UploadCard = ({ authenticated, handleAlert, mini}) => {
           onDrop={dropHandler}
           onDragOver={dragOverHandler}
         >
-          <Box sx={{ display: 'flex', p: 1, height: '100%' }} justifyContent="center" alignItems="center">
-            <Stack sx={{ zIndex: 0, width: '100%' }} alignItems="center" justifyContent="center">
+          <Box sx={{ display: 'flex', height: '100%' }} justifyContent="center" alignItems="center">
+            <Stack sx={{ zIndex: 0 }} alignItems="center" justifyContent="center">
               {!isSelected && (
                 <Input
                   id="icon-button-file"
@@ -220,13 +231,16 @@ const UploadCard = ({ authenticated, handleAlert, mini}) => {
               )}
             </Stack>
           </Box>
-          <Box
-            sx={{
+          <motion.div
+            animate={{
+              height: mini ? `${progress * 100}%` : '100%',
+              width: mini ? '100%' : `${progress * 100}%`,
+            }}
+            transition={progress === 0 ? { duration: 0 } : { duration: 0.6, ease: [0.25, 0.1, 0.25, 1] }}
+            style={{
               position: 'absolute',
               bottom: 0,
               zIndex: -1,
-              height: mini ? `${progress * 100}%` : '100%',
-              width: mini ? '100%' : `${progress * 100}%`,
               backgroundImage: 'linear-gradient(90deg, #BC00E6DF, #FF3729D9)',
               borderRadius: '10px',
             }}

--- a/app/client/src/components/nav/TranscodingStatus.js
+++ b/app/client/src/components/nav/TranscodingStatus.js
@@ -82,7 +82,7 @@ const TranscodingStatus = ({ open }) => {
       <Tooltip title={status.current_video || 'Not transcoding'} arrow placement="right">
         <Box sx={{ ...styles.card, ...styles.cardExpanded }}>
           <Grid container alignItems="center">
-            <Grid item sx={{ overflow: 'hidden' }}>
+            <Grid item xs={12} sx={{ overflow: 'hidden' }}>
               <Typography sx={styles.textPrimary}>
                 {status.total === 0 ? (
                   'Preparing transcode...'

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -771,7 +771,10 @@ def bulk_import(ctx, root):
             logger.info(f"A scan process is currently active... Aborting. (Remove {paths['data']/'fireshare.lock'} to continue anyway)")
             return
         util.create_lock(paths["data"])
-        
+
+        if current_app.config.get('ENABLE_TRANSCODING'):
+            util.write_transcoding_status(paths['data'], 0, 0, None, os.getpid())
+
         thumbnail_skip = current_app.config['THUMBNAIL_VIDEO_LOCATION'] or 0
         if thumbnail_skip > 0 and thumbnail_skip <= 100:
             thumbnail_skip = thumbnail_skip / 100
@@ -808,6 +811,7 @@ def bulk_import(ctx, root):
 
         logger.info(f"Finished bulk import. Timing info: {json.dumps(timing)}")
 
+        util.clear_transcoding_status(paths['data'])
         util.remove_lock(paths["data"])
 
 if __name__=="__main__":

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -49,20 +49,34 @@ AV1_CODEC_NAMES = frozenset([
 
 def lock_exists(path: Path):
     """
-    Checks if a lockfile currently exists
+    Checks if a lockfile exists and the owning process is still alive.
+    Automatically removes stale locks left by crashed processes.
     """
     lockfile = path / "fireshare.lock"
-    return lockfile.exists()
+    if not lockfile.exists():
+        return False
+    try:
+        with open(lockfile, 'r') as f:
+            pid = int(f.read().strip())
+        os.kill(pid, 0)  # signal 0 just checks liveness, sends nothing
+        return True
+    except (ValueError, ProcessLookupError, OSError):
+        logger.debug(f"Removing stale lockfile at {str(lockfile)}")
+        try:
+            os.remove(lockfile)
+        except Exception:
+            pass
+        return False
 
 def create_lock(path: Path):
     """
-    Creates the lock file
+    Creates the lock file, writing the current PID so stale locks can be detected.
     """
     lockfile = path / "fireshare.lock"
     if not lockfile.exists():
         logger.debug(f"A lockfile has been created at {str(lockfile)}")
-        fp = open(lockfile, 'x')
-        fp.close()
+        with open(lockfile, 'w') as f:
+            f.write(str(os.getpid()))
 
 def remove_lock(path: Path):
     """

--- a/app/server/requirements.txt
+++ b/app/server/requirements.txt
@@ -19,7 +19,7 @@ Werkzeug==2.1.2
 WTForms==3.0.1
 zipp==3.8.0
 xxhash==3.0.0
-apscheduler==3.9.1
+apscheduler==3.10.4
 python-ldap==3.4.3
 requests==2.27.1
 rapidfuzz==3.6.1


### PR DESCRIPTION
• The width issue was pretty straight forward, I used MUI's [grid](https://mui.com/material-ui/react-grid/) to create the layout of `TranscodingStatus.js.` However I didn't set any breakpoints for the text. Meaning it defaulted to XS which scales itself to the content. Meaning short file names would end up messing up the scaling.

Adding a `xs={12} `makes it scale to the width of container, fixing the issue. Simple fix but figured I should document it.
<img width="333" height="178" alt="Screenshot 2026-02-21 at 10 46 46 PM" src="https://github.com/user-attachments/assets/55d0e778-8ae3-485b-9168-9c78c25a5808" />

• `bulk_import` now writes to `transcoding_status.json`, so SSE can pick it up and start displaying the transcoding indicator. This means scheduled scans can now also activate `TranscodingStatus.js` component.

• Got rid of an issue where if a transcoding process would crash, it would keep a lock file stored, refusing to start a new scan after the app restarted. The lock file would have to be manually deleted to rest the scan. 
`lock_exists` now checks to see if there is a process, and if the process is dead, clears the lock file so the next scan can proceed normally.

Sorry again about the wait, long day, but simple fixes all around. 


 
