### PR TITLE
 Updated Update Notifications to now detect newer releases, fixed formatting

### DIFF
--- a/app/client/src/components/utils/AuthWrapper.js
+++ b/app/client/src/components/utils/AuthWrapper.js
@@ -2,32 +2,49 @@ import React from 'react'
 import { Navigate } from 'react-router-dom'
 import { AuthService } from '../../services'
 
+const RECHECK_INTERVAL = 12 * 60 * 60 * 1000 // 12 hours
+let lastCheckTime = 0
+
 const AuthWrapper = ({ children, redirect }) => {
   const [authed, setAuthed] = React.useState(true)
   const [checkingAuth, setCheckingAuth] = React.useState(true)
   const [showReleaseNotes, setShowReleaseNotes] = React.useState(false)
   const [releaseNotes, setReleaseNotes] = React.useState(null)
 
-  React.useEffect(() => {
-    async function isLoggedIn() {
-      try {
-        const response = (await AuthService.isLoggedIn()).data
-        // Handle both old (boolean) and new (object) response formats
-        if (typeof response === 'object') {
-          setAuthed(response.authenticated)
-          setShowReleaseNotes(response.show_release_notes || false)
-          setReleaseNotes(response.release_notes || null)
-        } else {
-          setAuthed(response)
-        }
-      } catch (err) {
-        setAuthed(false)
-        console.error(err)
+  const checkLogin = React.useCallback(async () => {
+    try {
+      const response = (await AuthService.isLoggedIn()).data
+      if (typeof response === 'object') {
+        setAuthed(response.authenticated)
+        setShowReleaseNotes(response.show_release_notes || false)
+        setReleaseNotes(response.release_notes || null)
+      } else {
+        setAuthed(response)
       }
-      setCheckingAuth(false)
+    } catch (err) {
+      setAuthed(false)
+      console.error(err)
     }
-    isLoggedIn()
+    lastCheckTime = Date.now()
   }, [])
+
+  React.useEffect(() => {
+    checkLogin().then(() => setCheckingAuth(false))
+
+    const interval = setInterval(checkLogin, RECHECK_INTERVAL)
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible' && Date.now() - lastCheckTime >= RECHECK_INTERVAL) {
+        checkLogin()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [checkLogin])
 
   if (checkingAuth) return <div></div>
 

--- a/app/client/src/views/Dashboard.js
+++ b/app/client/src/views/Dashboard.js
@@ -536,7 +536,7 @@ const Dashboard = ({
 
       {/* Release Notes Dialog */}
       <Dialog open={featureAlertOpen} onClose={handleFeatureAlertClose} maxWidth="sm" scroll="paper">
-        <DialogTitle>{releaseNotes?.name || `Update ${releaseNotes?.version}`}</DialogTitle>
+        <DialogTitle sx={{ fontSize: 18, fontWeight: 'bold', color: 'primary.main', textTransform: 'uppercase' }}>{`New Update Available - v${releaseNotes?.version}`}</DialogTitle>
         <DialogContent sx={{ maxHeight: '70vh', overflowY: 'auto' }}>
           <Box
             sx={{
@@ -552,8 +552,6 @@ const Dashboard = ({
                     // Escape HTML first
                     .replace(/</g, '&lt;')
                     .replace(/>/g, '&gt;')
-                    // Remove @username mentions
-                    .replace(/@[\w-]+/g, '')
                     // Headers
                     .replace(/^## (.+)$/gm, '<strong style="font-size: 1.1em;">$1</strong>')
                     .replace(/^### (.+)$/gm, '<strong>$1</strong>')
@@ -565,6 +563,11 @@ const Dashboard = ({
                       '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>',
                     )
                     .replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>')
+                    // Unordered lists
+                    .replace(/(?:^|\n)([*\-] .+(?:\n[*\-] .+)*)/g, (match) => {
+                      const items = match.trim().split('\n').map(li => `<li>${li.replace(/^[*\-] /, '')}</li>`).join('')
+                      return `<ul>${items}</ul>`
+                    })
                     // Line breaks
                     .replace(/\n\n/g, '</p><p>')
                     .replace(/\n/g, '<br/>')

--- a/app/client/src/views/FeedTesting.js
+++ b/app/client/src/views/FeedTesting.js
@@ -457,8 +457,8 @@ const FeedTesting = ({ authenticated, searchText, cardSize, listStyle, showRelea
 
       {/* Release Notes Dialog */}
       <Dialog open={featureAlertOpen} onClose={handleFeatureAlertClose} maxWidth="sm" scroll="paper">
-        <DialogTitle>
-          {releaseNotes?.name || `Update ${releaseNotes?.version}`}
+        <DialogTitle sx={{ fontSize: 18, fontWeight: 'bold', color: 'primary.main', textTransform: 'uppercase' }}>
+{`New Update Available - v${releaseNotes?.version}`}
         </DialogTitle>
         <DialogContent sx={{ maxHeight: '70vh', overflowY: 'auto' }}>
           <Box
@@ -475,8 +475,6 @@ const FeedTesting = ({ authenticated, searchText, cardSize, listStyle, showRelea
                     // Escape HTML first
                     .replace(/</g, '&lt;')
                     .replace(/>/g, '&gt;')
-                    // Remove @username mentions
-                    .replace(/@[\w-]+/g, '')
                     // Headers
                     .replace(/^## (.+)$/gm, '<strong style="font-size: 1.1em;">$1</strong>')
                     .replace(/^### (.+)$/gm, '<strong>$1</strong>')
@@ -485,6 +483,11 @@ const FeedTesting = ({ authenticated, searchText, cardSize, listStyle, showRelea
                     // Links
                     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
                     .replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>')
+                    // Unordered lists
+                    .replace(/(?:^|\n)([*\-] .+(?:\n[*\-] .+)*)/g, (match) => {
+                      const items = match.trim().split('\n').map(li => `<li>${li.replace(/^[*\-] /, '')}</li>`).join('')
+                      return `<ul>${items}</ul>`
+                    })
                     // Line breaks
                     .replace(/\n\n/g, '</p><p>')
                     .replace(/\n/g, '<br/>')

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -134,7 +134,7 @@ def config():
 
 # Cache for local app version and release notes (persists until server restart)
 _local_version_cache = {'version': None}
-_release_cache = {'data': None}
+_release_cache = {'data': None, 'fetched_at': 0}
 
 def _get_local_version():
     """Get the locally installed app version from package.json. Cached until server restart."""
@@ -158,13 +158,11 @@ def _get_local_version():
         return None
 
 def _fetch_release_notes():
-    """Fetch and cache release notes for the LOCAL version from GitHub. Cached until server restart."""
-    if _release_cache['data']:
+    """Fetch and cache the latest GitHub release. Cache expires after 12 hours."""
+    import time
+    cache_ttl = 12 * 60 * 60  # 12 hours
+    if _release_cache['data'] and (time.time() - _release_cache['fetched_at']) < cache_ttl:
         return _release_cache['data']
-
-    local_version = _get_local_version()
-    if not local_version:
-        return None
 
     try:
         response = requests.get(
@@ -178,18 +176,7 @@ def _fetch_release_notes():
         if not releases:
             return None
 
-        # Find the release matching the local version
-        target_release = None
-        for release in releases:
-            release_version = release.get('tag_name', '').lstrip('v')
-            if release_version == local_version:
-                target_release = release
-                break
-
-        # Fall back to latest if local version not found on GitHub
-        if not target_release:
-            logger.warning(f"Local version {local_version} not found on GitHub, using latest release")
-            target_release = releases[0]
+        target_release = releases[0]
 
         _release_cache['data'] = {
             'version': target_release.get('tag_name', '').lstrip('v'),
@@ -198,6 +185,7 @@ def _fetch_release_notes():
             'published_at': target_release.get('published_at', ''),
             'html_url': target_release.get('html_url', '')
         }
+        _release_cache['fetched_at'] = time.time()
         return _release_cache['data']
 
     except requests.RequestException as e:

--- a/app/server/fireshare/auth.py
+++ b/app/server/fireshare/auth.py
@@ -123,14 +123,20 @@ def loggedin():
     if not current_user.is_authenticated:
         return jsonify({'authenticated': False})
 
-    # Check if user should see release notes (runs once per app load)
+    # Check if a newer release exists and user hasn't dismissed it yet
     show_release_notes = False
     release_notes = None
     release_data = _fetch_release_notes()
     local_version = _get_local_version()
 
     if release_data and local_version:
-        if current_user.last_seen_version != local_version:
+        latest_version = release_data['version']
+        update_available = tuple(int(x) for x in latest_version.split('.')) > tuple(int(x) for x in local_version.split('.'))
+        if update_available:
+            current_app.logger.info(f"A new version of Fireshare is available! You have v{local_version}, latest is v{latest_version}.")
+        else:
+            current_app.logger.info(f"Fireshare is up to date (v{local_version}).")
+        if update_available and current_user.last_seen_version != latest_version:
             show_release_notes = True
             release_notes = release_data
 


### PR DESCRIPTION
Previously the update notes would check against the users local version and if it matched the newest version, would show them release notes. And only on first time startup of the app after an update.This is fine, however I realized we could re-use this logic to notify users of new releases instead, making it easier to let people know when there's a new version out (Since no one is checking the GitHub on a daily basis lol)

• api.py: `_fetch_release_notes()` now returns the latest GitHub release instead of matching the installed version. 
•  `isLoggedIn() ` call is now run every 12 hours via `setInterval` and on `visibilitychange` , so people with super long uptimes on their servers can still receive an update notification. 

 Also made some changes to the formatting of the update card:
• Changed the color scheme and styling to better fit the rest of our new design
• fixed a bug where @usernames would be hidden from the patch notes

<img width="927" height="827" alt="Screenshot 2026-03-05 at 4 14 48 PM" src="https://github.com/user-attachments/assets/b2cb0048-4086-469c-8bda-4322865a8959" />


