### PR TITLE
Disable iOS Safari input focus zoom

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -10,7 +10,7 @@
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Self host your media and share with unique links." />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />


### PR DESCRIPTION
Accessing Fireshare on mobile had a bad bug where tapping on any input box would zoom in the entire page, making you have to manually zoom back out to type it out. This wasn't necessary as the entire page is designed readable on mobile without the need to zoom in/out. This fix disables zoom on mobile so this doesn't trigger anymore. 