### PR TITLE
Replace thumbnail placeholder animation with skeleton shimmer and fade-in

### DIFF
--- a/app/client/src/components/admin/CompactVideoCard.js
+++ b/app/client/src/components/admin/CompactVideoCard.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Box, Typography, IconButton, Menu, MenuItem, ListItemIcon } from '@mui/material'
+import { Box, Typography, IconButton, Menu, MenuItem, ListItemIcon, Skeleton } from '@mui/material'
 import LinkIcon from '@mui/icons-material/Link'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
@@ -49,6 +49,7 @@ const CompactBetaVideoCard = ({
   const [suggestionIcon, setSuggestionIcon] = React.useState(null)
   const [editingTitle, setEditingTitle] = React.useState(false)
   const [titleDraft, setTitleDraft] = React.useState(title)
+  const [imgLoaded, setImgLoaded] = React.useState(false)
 
   const uiConfig = getSetting('ui_config')
   const canTagGames = authenticated || uiConfig?.allow_public_game_tag
@@ -59,6 +60,7 @@ const CompactBetaVideoCard = ({
     setIntVideo(video)
     setTitle(video.info?.title || (video.path ? video.path.split('/').pop().replace(/\.[^/.]+$/, '') : 'Untitled'))
     setDescription(video.info?.description || '')
+    setImgLoaded(false)
   }
   React.useEffect(() => {
     previousVideoRef.current = video
@@ -239,6 +241,20 @@ const CompactBetaVideoCard = ({
     >
       {/* Thumbnail */}
       <Box sx={{ aspectRatio: '16 / 9', overflow: 'hidden', position: 'relative' }}>
+        <Skeleton
+          variant="rectangular"
+          animation="wave"
+          width="100%"
+          height="100%"
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            opacity: imgLoaded ? 0 : 1,
+            transition: 'opacity 0.8s ease',
+            bgcolor: 'rgba(30, 60, 130, 0.4)',
+          }}
+        />
       <motion.div
         style={{ position: 'absolute', inset: 0, cursor: 'pointer' }}
         onClick={() => editMode ? onSelect?.(video.video_id) : openVideoHandler(video.video_id)}
@@ -259,12 +275,14 @@ const CompactBetaVideoCard = ({
               : `${URL}/api/video/poster?id=${video.video_id}`
           }`}
           alt=""
+          onLoad={() => setImgLoaded(true)}
           style={{
             width: '100%',
             height: '100%',
             objectFit: 'cover',
-            background: 'repeating-linear-gradient(45deg,#606dbc,#606dbc 10px,#465298 10px,#465298 20px)',
             display: 'block',
+            opacity: imgLoaded ? 1 : 0,
+            transition: 'opacity 0.8s ease',
           }}
         />
 


### PR DESCRIPTION
The new card design is fun but noticed some parts from the older build are still sticking out. I noticed the thumbnail loading was still the default stripe placeholder from MUI's skeleton.

<img width="1584" height="538" alt="Screenshot 2026-03-07 at 11 04 25 AM" src="https://github.com/user-attachments/assets/f65a3d4e-9592-4dc1-aea6-8da8d21eff97" />

We can definitely do better than this. So I swapped it with a MUI Skeleton wave shimmer instead. when the image is ready, a CSS opacity quickly fades in the thumbnail. This is way better for user feedback, it gives them an indicator that something is happening on the backend. 

![Screen Recording 2026-03-07 at 11 35 11 AM 2026-03-07 12_04_51](https://github.com/user-attachments/assets/c500ea89-388a-4e44-8e3d-cf570ccf6495)
