### PR TITLE
Add Video Player Modal redesign, arrow key navigation to modal

### DIFF
--- a/app/client/src/components/admin/CompactVideoCard.js
+++ b/app/client/src/components/admin/CompactVideoCard.js
@@ -61,7 +61,7 @@ const CompactBetaVideoCard = ({
     const v = videoRef.current
     if (!v) return
     if (hover) {
-      const { has_480p, has_720p, has_1080p } = video.info || {}
+      const { has_480p, has_720p, has_1080p } = intVideo?.info || video.info || {}
       v.src = has_480p ? getVideoUrl(video.video_id, '480p', video.extension)
         : has_720p ? getVideoUrl(video.video_id, '720p', video.extension)
         : has_1080p ? getVideoUrl(video.video_id, '1080p', video.extension)
@@ -73,7 +73,7 @@ const CompactBetaVideoCard = ({
       v.removeAttribute('src')
       v.load()
     }
-  }, [hover, video.video_id, video.extension, video.info])
+  }, [hover, video.video_id, video.extension, video.info, intVideo?.info])
 
   const cardRef = React.useRef(null)
   const isTouchDevice = React.useRef(typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0))
@@ -216,6 +216,38 @@ const gameName = game?.name || ''
   const filenameFallback = video.path
     ? video.path.split('/').pop().replace(/\.[^/.]+$/, '')
     : 'Untitled'
+
+  const refreshVideoDetails = async () => {
+    try {
+      const refreshed = (await VideoService.getDetails(video.video_id)).data
+      setIntVideo(refreshed)
+      setPrivateView(refreshed.info?.private)
+      setTitle(refreshed.info?.title || filenameFallback)
+      setDescription(refreshed.info?.description || '')
+    } catch (_) {}
+  }
+
+  const handleTranscode = async () => {
+    try {
+      const response = await ConfigService.startTranscodingVideo(video.video_id)
+      const status = response?.data?.status
+      alertHandler?.({
+        type: 'info',
+        message: status === 'queued' ? 'Transcode queued.' : 'Transcode started.',
+        open: true,
+      })
+      refreshVideoDetails()
+      setTimeout(refreshVideoDetails, 1000)
+    } catch (err) {
+      alertHandler?.({
+        type: 'error',
+        message: err.response?.data?.includes('not enabled')
+          ? 'Transcoding is disabled. Add ENABLE_TRANSCODING=true to your Docker environment variables.'
+          : 'Failed to start transcoding.',
+        open: true,
+      })
+    }
+  }
 
   const handleTitleSave = async () => {
     setEditingTitle(false)
@@ -682,7 +714,7 @@ const gameName = game?.name || ''
       >
         {[
           { label: 'Edit',       Icon: EditIcon,           color: '#FFFFFFE6', requiresAuth: true,  onClick: () => setDetailsModalOpen(true) },
-          { label: 'Transcode',  Icon: SlowMotionVideoIcon, color: '#FFFFFFE6', requiresAuth: true, onClick: () => ConfigService.startTranscodingVideo(video.video_id).catch((err) => alertHandler?.({ type: 'error', message: err.response?.data?.includes('not enabled') ? 'Transcoding is disabled. Add ENABLE_TRANSCODING=true to your Docker environment variables.' : 'Failed to start transcoding.', open: true })) },
+          { label: 'Transcode',  Icon: SlowMotionVideoIcon, color: '#FFFFFFE6', requiresAuth: true, onClick: handleTranscode },
           { label: 'Copy Link',  Icon: LinkIcon,           color: '#FFFFFFE6', onClick: () => { navigator.clipboard.writeText(`${PURL}${video.video_id}`); alertHandler?.({ type: 'info', message: 'Link copied to clipboard', open: true }) } },
           { label: 'Delete',     Icon: DeleteOutlineIcon,  color: '#EF5350',  danger: true, requiresAuth: true, onClick: () => setDeleteModalOpen(true) },
         ].filter(item => !item.requiresAuth || authenticated).map(({ label, Icon, color, danger, onClick }) => (

--- a/app/client/src/components/admin/VideoCards.js
+++ b/app/client/src/components/admin/VideoCards.js
@@ -135,6 +135,8 @@ const BetaVideoCards = ({
         feedView={feedView}
         authenticated={authenticated}
         updateCallback={handleUpdate}
+        onNext={() => { const i = vids.findIndex(v => v.video_id === videoModal.id); if (i < vids.length - 1) setVideoModal({ open: true, id: vids[i + 1].video_id }) }}
+        onPrev={() => { const i = vids.findIndex(v => v.video_id === videoModal.id); if (i > 0) setVideoModal({ open: true, id: vids[i - 1].video_id }) }}
       />
       <SnackbarAlert
         severity={alert.type}

--- a/app/client/src/components/misc/VideoJSPlayer.js
+++ b/app/client/src/components/misc/VideoJSPlayer.js
@@ -28,6 +28,8 @@ const VideoJSPlayer = ({
   controls = true,
   fluid = true,
   fill = false,
+  aspectRatio,
+  playsinline = false,
   onTimeUpdate,
   onReady,
   startTime,
@@ -58,6 +60,8 @@ const VideoJSPlayer = ({
         responsive: true,
         fluid,
         fill,
+        playsinline,
+        ...(aspectRatio && { aspectRatio }),
         poster,
         preload: 'auto',
         html5: {

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -1,9 +1,12 @@
 import React, { useEffect, useState } from 'react'
-import { Box, Button, Divider, IconButton, Modal, Paper, TextField, Tooltip, Typography } from '@mui/material'
+import { Box, Button, Divider, IconButton, Modal, Paper, Popover, TextField, Tooltip, Typography } from '@mui/material'
 import { motion } from 'framer-motion'
+import { DayPicker } from 'react-day-picker'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import CloseIcon from '@mui/icons-material/Close'
+import './datepicker-dark.css'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import { copyToClipboard, getPublicWatchUrl, getServedBy, getUrl, getVideoSources, getSetting } from '../../common/utils'
@@ -63,6 +66,49 @@ const actionBtnSx = {
 
 const SIDEBAR_WIDTH = 'clamp(280px, 24vw, 420px)'
 
+const timeInputStyle = {
+  background: '#FFFFFF0D',
+  border: '1px solid #FFFFFF26',
+  borderRadius: 6,
+  color: 'white',
+  fontSize: 13,
+  padding: '4px 8px',
+  colorScheme: 'dark',
+  flex: 1,
+}
+
+const DateField = ({ selectedDate, selectedTime, onDateChange, onTimeChange }) => {
+  const [anchor, setAnchor] = React.useState(null)
+  const display = selectedDate
+    ? selectedDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) + (selectedTime ? ` at ${selectedTime}` : '')
+    : null
+  return (
+    <>
+      <Box onClick={(e) => setAnchor(e.currentTarget)} sx={{ ...rowBoxSx, cursor: 'pointer', py: 1.1, '&:hover': { borderColor: '#FFFFFF55' } }}>
+        <CalendarMonthIcon sx={{ color: '#FFFFFF66', fontSize: 20 }} />
+        <Typography sx={{ color: display ? 'white' : '#FFFFFF4D', fontSize: 14, flex: 1 }}>
+          {display || 'Pick a date…'}
+        </Typography>
+        {selectedDate && (
+          <IconButton size="small" onClick={(e) => { e.stopPropagation(); onDateChange(null); onTimeChange('') }} sx={{ color: '#FFFFFF66', '&:hover': { color: 'white' }, p: 0.25 }}>
+            <CloseIcon sx={{ fontSize: 16 }} />
+          </IconButton>
+        )}
+      </Box>
+      <Popover open={Boolean(anchor)} anchorEl={anchor} onClose={() => setAnchor(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }} transformOrigin={{ vertical: 'top', horizontal: 'left' }} slotProps={{ paper: { sx: { bgcolor: 'transparent', boxShadow: 'none', mt: 0.5 } } }}>
+        <div className="fireshare-rdp">
+          <DayPicker animate mode="single" selected={selectedDate} onSelect={(d) => onDateChange(d || null)} defaultMonth={selectedDate || new Date()} />
+          <Box sx={{ px: 1, pb: 1, display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <Typography sx={{ color: '#FFFFFFB3', fontSize: 13 }}>Time</Typography>
+            <input type="time" value={selectedTime} onChange={(e) => onTimeChange(e.target.value)} style={timeInputStyle} />
+            <Button size="small" variant="contained" onClick={() => setAnchor(null)} sx={{ bgcolor: '#3399FF', '&:hover': { bgcolor: '#1976D2' }, minWidth: 60 }}>Done</Button>
+          </Box>
+        </div>
+      </Popover>
+    </>
+  )
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCallback, onNext, onPrev }) => {
@@ -70,6 +116,8 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   const [description, setDescription] = React.useState('')
   const [updateable, setUpdatable] = React.useState(false)
   const [privateView, setPrivateView] = React.useState(false)
+  const [selectedDate, setSelectedDate] = React.useState(null)
+  const [selectedTime, setSelectedTime] = React.useState('')
   const [vid, setVideo] = React.useState(null)
   const [viewAdded, setViewAdded] = React.useState(false)
   const [alert, setAlert] = React.useState({ open: false, type: 'info', message: '' })
@@ -141,6 +189,15 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
         setDescription(details.info?.description)
         setPrivateView(details.info?.private)
         setUpdatable(false)
+        if (details.recorded_at) {
+          const d = new Date(details.recorded_at)
+          const pad = (n) => n.toString().padStart(2, '0')
+          setSelectedDate(d)
+          setSelectedTime(`${pad(d.getHours())}:${pad(d.getMinutes())}`)
+        } else {
+          setSelectedDate(null)
+          setSelectedTime('')
+        }
         try {
           const gameData = (await GameService.getVideoGame(videoId)).data
           setSelectedGame(gameData || null)
@@ -155,6 +212,8 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
       setTitle('')
       setDescription('')
       setSelectedGame(null)
+      setSelectedDate(null)
+      setSelectedTime('')
       setEditMode(false)
       fetch()
     }
@@ -184,10 +243,17 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
     if (e.button === 1) window.open(`${PURL}${vid.video_id}`, '_blank')
   }
 
+  const getRecordedAtISO = () => {
+    if (!selectedDate) return null
+    const d = new Date(selectedDate)
+    if (selectedTime) { const [h, m] = selectedTime.split(':'); d.setHours(+h, +m, 0, 0) }
+    return d.toISOString()
+  }
+
   const update = async () => {
     if (updateable && authenticated) {
       try {
-        await VideoService.updateDetails(vid.video_id, { title, description })
+        await VideoService.updateDetails(vid.video_id, { title, description, recorded_at: getRecordedAtISO() })
         setUpdatable(false)
         setEditMode(false)
         updateCallback({ id: vid.video_id, title, description })
@@ -494,6 +560,19 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                         />
                       </Box>
                     )}
+                  </Box>
+                )}
+
+                {/* Date picker (edit mode only) */}
+                {editMode && (
+                  <Box>
+                    <Typography sx={labelSx}>Recorded Date</Typography>
+                    <DateField
+                      selectedDate={selectedDate}
+                      selectedTime={selectedTime}
+                      onDateChange={(d) => { setSelectedDate(d); setUpdatable(true) }}
+                      onTimeChange={(t) => { setSelectedTime(t); setUpdatable(true) }}
+                    />
                   </Box>
                 )}
 

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react'
-import { Box, Button, ButtonGroup, Grid, IconButton, InputAdornment, Modal, Paper, Slide, TextField } from '@mui/material'
+import { Box, Divider, IconButton, Modal, Paper, Slide, TextField, Tooltip, Typography } from '@mui/material'
 import LinkIcon from '@mui/icons-material/Link'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import ShuffleIcon from '@mui/icons-material/Shuffle'
 import SaveIcon from '@mui/icons-material/Save'
 import CloseIcon from '@mui/icons-material/Close'
+import EditIcon from '@mui/icons-material/Edit'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import VisibilityIcon from '@mui/icons-material/Visibility'
-import SportsEsportsIcon from '@mui/icons-material/SportsEsports'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { copyToClipboard, getPublicWatchUrl, getServedBy, getUrl, getVideoSources, getSetting } from '../../common/utils'
 import { ConfigService, VideoService, GameService } from '../../services'
@@ -19,6 +19,54 @@ const URL = getUrl()
 const PURL = getPublicWatchUrl()
 const SERVED_BY = getServedBy()
 
+// ─── Shared style constants (matching UpdateDetailsModal / CompactVideoCard) ──
+
+const labelSx = {
+  fontSize: 11,
+  color: '#FFFFFFB3',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  mb: 0.75,
+}
+
+const inputSx = {
+  '& .MuiOutlinedInput-root': {
+    color: 'white',
+    bgcolor: '#FFFFFF0D',
+    borderRadius: '8px',
+    '& fieldset': { borderColor: '#FFFFFF26' },
+    '&:hover fieldset': { borderColor: '#FFFFFF55' },
+    '&.Mui-focused fieldset': { borderColor: '#3399FF' },
+  },
+  '& .MuiInputBase-input.Mui-disabled': {
+    WebkitTextFillColor: 'rgba(255, 255, 255, 0.85)',
+  },
+}
+
+const rowBoxSx = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 1,
+  bgcolor: '#FFFFFF0D',
+  border: '1px solid #FFFFFF26',
+  borderRadius: '8px',
+  px: 1.5,
+  py: 1,
+}
+
+const actionBtnSx = {
+  color: '#FFFFFFB3',
+  bgcolor: '#FFFFFF0D',
+  border: '1px solid #FFFFFF1A',
+  borderRadius: '8px',
+  p: 1,
+  '&:hover': { bgcolor: '#FFFFFF1A', color: 'white' },
+}
+
+const SIDEBAR_WIDTH = 'clamp(280px, 24vw, 420px)'
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
 const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCallback }) => {
   const [title, setTitle] = React.useState('')
   const [description, setDescription] = React.useState('')
@@ -29,9 +77,9 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   const [alert, setAlert] = React.useState({ open: false, type: 'info', message: '' })
   const [autoplay, setAutoplay] = useState(false)
   const [selectedGame, setSelectedGame] = React.useState(null)
+  const [editMode, setEditMode] = React.useState(false)
 
   const playerRef = React.useRef()
-  const videoContainerRef = React.useRef(null)
 
   const getRandomVideo = async () => {
     try {
@@ -53,15 +101,14 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   useEffect(() => {
     const fetchConfig = async () => {
       try {
-        const result = await ConfigService.getConfig();  
-        setAutoplay(result.data?.autoplay || false);  
+        const result = await ConfigService.getConfig()
+        setAutoplay(result.data?.autoplay || false)
       } catch (error) {
-        console.error('Error fetching config:', error);
+        console.error('Error fetching config:', error)
       }
-    };
-
-    fetchConfig();  
-  }, []);  
+    }
+    fetchConfig()
+  }, [])
 
   React.useEffect(() => {
     async function fetch() {
@@ -73,31 +120,22 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
         setDescription(details.info?.description)
         setPrivateView(details.info?.private)
         setUpdatable(false)
-        // Fetch linked game
         try {
           const gameData = (await GameService.getVideoGame(videoId)).data
-          if (gameData) {
-            setSelectedGame(gameData)
-          } else {
-            setSelectedGame(null)
-          }
+          setSelectedGame(gameData || null)
         } catch (err) {
           setSelectedGame(null)
         }
       } catch (err) {
-        setAlert({
-          type: 'error',
-          message: 'Unable to load video details',
-          open: true,
-        })
+        setAlert({ type: 'error', message: 'Unable to load video details', open: true })
       }
     }
     if (videoId) {
-      // Reset video state before loading new video to prevent showing old data
       setVideo(null)
       setTitle('')
       setDescription('')
       setSelectedGame(null)
+      setEditMode(false)
       fetch()
     }
   }, [videoId])
@@ -106,18 +144,9 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
     try {
       await GameService.linkVideoToGame(vid.video_id, game.id)
       setSelectedGame(game)
-      setAlert({
-        type: 'success',
-        message: `Linked to ${game.name}`,
-        open: true,
-      })
+      setAlert({ type: 'success', message: `Linked to ${game.name}`, open: true })
     } catch (err) {
-      console.error('Error linking game:', err)
-      setAlert({
-        type: 'error',
-        message: 'Failed to link game',
-        open: true,
-      })
+      setAlert({ type: 'error', message: 'Failed to link game', open: true })
     }
   }
 
@@ -125,25 +154,14 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
     try {
       await GameService.unlinkVideoFromGame(vid.video_id)
       setSelectedGame(null)
-      setAlert({
-        type: 'info',
-        message: 'Game link removed',
-        open: true,
-      })
+      setAlert({ type: 'info', message: 'Game link removed', open: true })
     } catch (err) {
-      console.error('Error unlinking game:', err)
-      setAlert({
-        type: 'error',
-        message: 'Failed to unlink game',
-        open: true,
-      })
+      setAlert({ type: 'error', message: 'Failed to unlink game', open: true })
     }
   }
 
   const handleMouseDown = (e) => {
-    if (e.button === 1) {
-      window.open(`${PURL}${vid.video_id}`, '_blank')
-    }
+    if (e.button === 1) window.open(`${PURL}${vid.video_id}`, '_blank')
   }
 
   const update = async () => {
@@ -151,18 +169,11 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
       try {
         await VideoService.updateDetails(vid.video_id, { title, description })
         setUpdatable(false)
+        setEditMode(false)
         updateCallback({ id: vid.video_id, title, description })
-        setAlert({
-          type: 'success',
-          message: 'Details Updated',
-          open: true,
-        })
+        setAlert({ type: 'success', message: 'Details Updated', open: true })
       } catch (err) {
-        setAlert({
-          type: 'error',
-          message: 'An error occurred trying to update the title',
-          open: true,
-        })
+        setAlert({ type: 'error', message: 'An error occurred trying to update the title', open: true })
       }
     }
   }
@@ -174,7 +185,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
         updateCallback({ id: vid.video_id, private: !privateView })
         setAlert({
           type: privateView ? 'info' : 'warning',
-          message: privateView ? `Added to your public feed` : `Removed from your public feed`,
+          message: privateView ? 'Added to your public feed' : 'Removed from your public feed',
           open: true,
         })
         setPrivateView(!privateView)
@@ -185,16 +196,12 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   }
 
   const handleTitleChange = (newValue) => {
-    if (newValue) {
-      setUpdatable(newValue !== vid.info?.title || description !== vid.info?.description)
-    }
+    if (newValue) setUpdatable(newValue !== vid.info?.title || description !== vid.info?.description)
     setTitle(newValue)
   }
 
   const handleDescriptionChange = (newValue) => {
-    if (newValue) {
-      setUpdatable(newValue !== vid.info?.description || title !== vid.info?.title)
-    }
+    if (newValue) setUpdatable(newValue !== vid.info?.description || title !== vid.info?.title)
     setDescription(newValue)
   }
 
@@ -202,14 +209,10 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
     let currentTime = 0
     if (playerRef.current && typeof playerRef.current.currentTime === 'function') {
       const time = playerRef.current.currentTime()
-      currentTime = (time && !isNaN(time)) ? time : 0
+      currentTime = time && !isNaN(time) ? time : 0
     }
     copyToClipboard(`${PURL}${vid.video_id}?t=${currentTime}`)
-    setAlert({
-      type: 'info',
-      message: 'Time stamped link copied to clipboard',
-      open: true,
-    })
+    setAlert({ type: 'info', message: 'Time stamped link copied to clipboard', open: true })
   }
 
   const handleTimeUpdate = (e) => {
@@ -225,241 +228,347 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
     }
   }
 
-
-
   const getPosterUrl = () => {
-    if (SERVED_BY === 'nginx') {
-      return `${URL}/_content/derived/${vid.video_id}/poster.jpg`
-    }
+    if (SERVED_BY === 'nginx') return `${URL}/_content/derived/${vid.video_id}/poster.jpg`
     return `${URL}/api/video/poster?id=${vid.video_id}`
   }
 
-  // Constrain video player dimensions to fit within available space while maintaining aspect ratio
-  React.useEffect(() => {
-    const container = videoContainerRef.current
-    if (!container) return
-
-    const aspectRatio = (vid?.info?.width && vid?.info?.height)
-      ? vid.info.width / vid.info.height
-      : 16 / 9
-
-    const computeSize = () => {
-      const availW = container.clientWidth
-      const availH = container.clientHeight
-      if (availW <= 0 || availH <= 0) return
-
-      let w = availW
-      let h = w / aspectRatio
-
-      if (h > availH) {
-        h = availH
-        w = h * aspectRatio
-      }
-    }
-
-    const observer = new ResizeObserver(computeSize)
-    observer.observe(container)
-
-    return () => observer.disconnect()
-  }, [vid?.info?.width, vid?.info?.height])
-
   if (!vid) return null
+
+  // Video aspect ratio — drives the modal height via CSS min().
+  const ar = Number(((vid?.info?.width || 16) / (vid?.info?.height || 9)).toFixed(6))
+  // Height: fit within viewport (minus 96px padding each side) and available width minus sidebar.
+  const videoH_css = `min(calc((100vw - 192px - clamp(280px, 24vw, 420px)) / ${ar}), calc(100vh - 192px))`
+  // Width: height × aspect ratio.
+  const videoW_css = `calc((${videoH_css}) * ${ar})`
 
   return (
     <>
       <SnackbarAlert severity={alert.type} open={alert.open} setOpen={(open) => setAlert({ ...alert, open })}>
         {alert.message}
       </SnackbarAlert>
+
       <Modal open={open} onClose={onClose} closeAfterTransition disableAutoFocus={true}>
         <Slide in={open}>
-          <Paper sx={{ height: '100%', borderRadius: '0px', overflow: 'hidden', background: 'rgba(0, 0, 0, 0.4)', px: '20px', pt: '20px', pb: 0 }}>
-            <IconButton
-              color="inherit"
-              onClick={onClose}
-              aria-label="close"
+          {/* Centering wrapper — Slide animates this, click-outside closes modal */}
+          <Box
+            tabIndex={-1}
+            sx={{
+              outline: 'none',
+              display: 'flex',
+              height: '100%',
+              alignItems: 'center',
+              justifyContent: 'center',
+              // Full-screen on small viewports, padded on desktop
+              p: { xs: 0, md: '96px' },
+            }}
+            onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+          >
+            <Paper
               sx={{
-                position: 'absolute',
-                background: 'rgba(255,255,255,0.25)',
-                ':hover': {
-                  background: 'rgba(255,255,255,0.5)',
-                },
-                width: 50,
-                height: 50,
-                top: 16,
-                right: 16,
-                zIndex: 100,
-                padding: 0,
+                borderRadius: { xs: 0, md: '12px' },
+                overflow: 'hidden',
+                bgcolor: '#020D1A',
+                display: 'flex',
+                flexDirection: { xs: 'column', md: 'row' },
+                // Small: fill entire screen. Desktop: sized to video AR.
+                width: { xs: '100%', md: 'auto' },
+                height: { xs: '100%', md: videoH_css },
+                maxHeight: '100%',
+                maxWidth: '100%',
               }}
             >
-              <CloseIcon sx={{ width: 35, height: 35 }} />
-            </IconButton>
-            <div style={{ display: 'flex', height: '100%', flexDirection: 'column', alignItems: 'center' }}>
-              <div ref={videoContainerRef} style={{ flex: '1 1 auto', minHeight: 0, width: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-                  <VideoJSPlayer
-                    key={vid.video_id}
-                    sources={getVideoSources(vid.video_id, vid?.info, vid.extension)}
-                    poster={getPosterUrl()}
-                    autoplay={autoplay}
-                    controls={true}
-                    onTimeUpdate={handleTimeUpdate}
-                    onReady={(player) => {
-                      playerRef.current = player
-                    }}
-                    fluid={false}
-                    fill={true}
-                  />
-              </div>
-              <div style={{ flex: '0 0 auto', marginTop: 8, marginBottom: 8}}>
-                <ButtonGroup variant="contained" onClick={(e) => e.stopPropagation()}>
-                  <Button onClick={getRandomVideo}>
-                    <ShuffleIcon />
-                  </Button>
-                  {authenticated && (
-                    <Button onClick={handlePrivacyChange} edge="end">
-                      {privateView ? <VisibilityOffIcon /> : <VisibilityIcon />}
-                    </Button>
-                  )}
-                  <TextField
-                    sx={{
-                      textAlign: 'center',
-                      background: 'rgba(50, 50, 50, 0.9)',
-                      '& .MuiOutlinedInput-root': {
-                        borderRadius: 0,
-                        width: {
-                          xs: 'auto',
-                          sm: 350,
-                          md: 450,
-                        },
-                      },
-                      '& .MuiInputBase-input.Mui-disabled': {
-                        WebkitTextFillColor: '#fff',
-                      },
-                    }}
-                    size="small"
-                    value={title}
-                    placeholder="Video Title"
-                    disabled={!authenticated}
-                    onChange={(e) => handleTitleChange(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && update()}
-                    InputProps={{
-                      endAdornment: authenticated && (
-                        <InputAdornment position="end">
-                          <IconButton
-                            disabled={!updateable}
-                            sx={
-                              updateable
-                                ? {
-                                    animation: 'blink-blue 0.5s ease-in-out infinite alternate',
-                                  }
-                                : {}
-                            }
-                            onClick={update}
-                            edge="end"
-                          >
-                            <SaveIcon />
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    }}
-                  />
-                  <CopyToClipboard text={`${PURL}${vid.video_id}`}>
-                    <Button
-                      onMouseDown={handleMouseDown}
-                      onClick={() =>
-                        setAlert({
-                          type: 'info',
-                          message: 'Link copied to clipboard',
-                          open: true,
-                        })
-                      }
-                    >
-                      <LinkIcon />
-                    </Button>
-                  </CopyToClipboard>
-                  <Button onClick={copyTimestamp}>
-                    <AccessTimeIcon />
-                  </Button>
-                </ButtonGroup>
-                {(authenticated || description) && (
-                  <Paper sx={{ mt: 1, background: 'rgba(50, 50, 50, 0.9)' }}>
+            {/* ── Left: Video Player ───────────────────────────────────────── */}
+            <Box
+              sx={{
+                position: 'relative',
+                flexShrink: 0,
+                bgcolor: '#020D1A',
+                // Desktop: explicit dimensions from CSS; mobile: 100% wide, AR height.
+                width: { xs: '100%', md: videoW_css },
+                height: { xs: 'auto', md: '100%' },
+                aspectRatio: { xs: `${vid?.info?.width || 16} / ${vid?.info?.height || 9}`, md: 'initial' },
+              }}
+            >
+              <VideoJSPlayer
+                key={vid.video_id}
+                sources={getVideoSources(vid.video_id, vid?.info, vid.extension)}
+                poster={getPosterUrl()}
+                autoplay={autoplay}
+                controls={true}
+                onTimeUpdate={handleTimeUpdate}
+                onReady={(player) => { playerRef.current = player }}
+                fill={true}
+                fluid={false}
+                playsinline={true}
+              />
+            </Box>
+
+            {/* ── Right: Info Sidebar ──────────────────────────────────────── */}
+            <Box
+              sx={{
+                width: { xs: '100%', md: SIDEBAR_WIDTH },
+                flexShrink: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                bgcolor: '#041223',
+                borderLeft: { md: '1px solid #FFFFFF14' },
+                borderTop: { xs: '1px solid #FFFFFF14', md: 'none' },
+                overflow: 'hidden',
+              }}
+            >
+              {/* Header */}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  px: 2.5,
+                  pt: 2,
+                  pb: 1.75,
+                  flexShrink: 0,
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    fontSize: 12,
+                    color: '#FFFFFF66',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.12em',
+                  }}
+                >
+                  Now Playing
+                </Typography>
+                <IconButton
+                  onClick={onClose}
+                  size="small"
+                  sx={{
+                    color: '#FFFFFF80',
+                    bgcolor: '#FFFFFF14',
+                    borderRadius: '8px',
+                    '&:hover': { bgcolor: '#FFFFFF2A', color: 'white' },
+                    width: 30,
+                    height: 30,
+                  }}
+                >
+                  <CloseIcon sx={{ fontSize: 17 }} />
+                </IconButton>
+              </Box>
+
+              <Divider sx={{ borderColor: '#FFFFFF14', flexShrink: 0 }} />
+
+              {/* Scrollable info content */}
+              <Box
+                sx={{
+                  flex: 1,
+                  overflowY: 'auto',
+                  px: 2.5,
+                  pt: 2.5,
+                  pb: 2,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2.5,
+                  '&::-webkit-scrollbar': { width: 4 },
+                  '&::-webkit-scrollbar-track': { bgcolor: 'transparent' },
+                  '&::-webkit-scrollbar-thumb': { bgcolor: '#FFFFFF26', borderRadius: 2 },
+                }}
+              >
+                {/* Title */}
+                <Box>
+                  {editMode ? (
                     <TextField
                       fullWidth
-                      disabled={!authenticated}
-                      sx={{
-                        '& .MuiInputBase-input.Mui-disabled': {
-                          WebkitTextFillColor: '#fff',
-                        },
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          border: 'none',
-                        },
-                      }}
                       size="small"
-                      placeholder="Enter a video description..."
-                      value={description || ''}
-                      onChange={(e) => handleDescriptionChange(e.target.value)}
-                      rows={2}
-                      multiline
+                      value={title || ''}
+                      placeholder="Video Title"
+                      onChange={(e) => handleTitleChange(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && update()}
                       onClick={(e) => e.stopPropagation()}
+                      autoFocus
+                      sx={inputSx}
                     />
-                  </Paper>
-                )}
-                {/* Game linking */}
-                {(authenticated || getSetting('ui_config')?.allow_public_game_tag) && (
-                  <Paper sx={{ mt: 1, background: 'rgba(50, 50, 50, 0.9)' }}>
+                  ) : (
+                    <Typography sx={{ fontWeight: 700, fontSize: 17, color: 'white', lineHeight: 1.4 }}>
+                      {title || 'Untitled'}
+                    </Typography>
+                  )}
+                </Box>
+
+                {/* Game */}
+                {(selectedGame || (editMode && (authenticated || getSetting('ui_config')?.allow_public_game_tag))) && (
+                  <Box>
                     {selectedGame ? (
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'space-between',
-                          height: 40,
-                          pl: 1.75,
-                          pr: 0.5,
-                        }}
-                      >
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <SportsEsportsIcon sx={{ color: 'rgba(255, 255, 255, 0.7)' }} />
-                          <Box
-                            component="span"
-                            sx={{
-                              color: 'rgba(255, 255, 255, 0.7)',
-                              fontSize: '0.875rem',
-                            }}
-                          >
-                            {selectedGame.name}
-                          </Box>
-                        </Box>
-                        <IconButton
-                          onClick={handleUnlinkGame}
-                          size="small"
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: '#FFFFFF0D', border: '1px solid #FFFFFF26', borderRadius: '8px', px: 1.5, py: 1 }}>
+                        {selectedGame.icon_url && (
+                          <img
+                            src={selectedGame.icon_url}
+                            alt=""
+                            style={{ width: 20, height: 20, objectFit: 'contain', borderRadius: 3, flexShrink: 0 }}
+                          />
+                        )}
+                        <Typography
+                          component={selectedGame.steamgriddb_id ? 'a' : 'span'}
+                          href={selectedGame.steamgriddb_id ? `#/games/${selectedGame.steamgriddb_id}` : undefined}
+                          onClick={selectedGame.steamgriddb_id ? (e) => e.stopPropagation() : undefined}
                           sx={{
-                            color: 'rgba(255, 255, 255, 0.5)',
-                            '&:hover': {
-                              color: 'rgba(255, 255, 255, 0.9)',
-                            },
+                            fontSize: 13,
+                            color: '#FFFFFFB3',
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.08em',
+                            flex: 1,
+                            textDecoration: 'none',
+                            ...(selectedGame.steamgriddb_id && {
+                              cursor: 'pointer',
+                              '&:hover': { color: '#3399FF', textDecoration: 'underline' },
+                            }),
                           }}
                         >
-                          <CloseIcon fontSize="small" />
-                        </IconButton>
+                          {selectedGame.name}
+                        </Typography>
+                        {editMode && (
+                          <IconButton
+                            size="small"
+                            onClick={handleUnlinkGame}
+                            sx={{ color: '#FFFFFF66', '&:hover': { color: 'white' }, p: 0.25 }}
+                          >
+                            <CloseIcon sx={{ fontSize: 16 }} />
+                          </IconButton>
+                        )}
                       </Box>
                     ) : (
-                      <GameSearch
-                        onGameLinked={handleGameLinked}
-                        onError={(err) =>
-                          setAlert({
-                            open: true,
-                            type: 'error',
-                            message: err.response?.data || 'Error linking game',
-                          })
-                        }
-                        placeholder="Search for a game..."
-                      />
+                      <Box
+                        sx={{
+                          ...rowBoxSx,
+                          py: 0,
+                          overflow: 'hidden',
+                          '& .MuiInputBase-root': { color: 'white', px: 0 },
+                          '& input::placeholder': { color: '#FFFFFF66', opacity: 1 },
+                          '& .MuiSvgIcon-root': { color: '#FFFFFF66' },
+                        }}
+                      >
+                        <GameSearch
+                          onGameLinked={handleGameLinked}
+                          onError={(err) =>
+                            setAlert({ open: true, type: 'error', message: err.response?.data || 'Error linking game' })
+                          }
+                          placeholder="Search for a game..."
+                        />
+                      </Box>
                     )}
-                  </Paper>
+                  </Box>
                 )}
-              </div>
-            </div>
-          </Paper>
+
+                {/* Description */}
+                {(editMode || description) && (
+                  <Box>
+                    <Typography sx={labelSx}>Description</Typography>
+                    {editMode ? (
+                      <TextField
+                        fullWidth
+                        multiline
+                        rows={4}
+                        size="small"
+                        placeholder="Enter a video description..."
+                        value={description || ''}
+                        onChange={(e) => handleDescriptionChange(e.target.value)}
+                        onClick={(e) => e.stopPropagation()}
+                        sx={inputSx}
+                      />
+                    ) : (
+                      <Box sx={{ bgcolor: '#FFFFFF0D', border: '1px solid #FFFFFF26', borderRadius: '8px', px: 1.5, py: 1 }}>
+                        <Typography sx={{ fontSize: 14, color: '#FFFFFFB3', lineHeight: 1.6 }}>{description}</Typography>
+                      </Box>
+                    )}
+                  </Box>
+                )}
+
+                {/* Spacer — future "Related Videos" will live here */}
+                <Box sx={{ flex: 1 }} />
+              </Box>
+
+              <Divider sx={{ borderColor: '#FFFFFF14', flexShrink: 0 }} />
+
+              {/* Action buttons footer */}
+              <Box
+                sx={{
+                  px: 2.5,
+                  py: 2,
+                  flexShrink: 0,
+                  display: 'flex',
+                  gap: 1,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <Tooltip title="Random video">
+                  <IconButton size="small" onClick={getRandomVideo} sx={actionBtnSx}>
+                    <ShuffleIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </Tooltip>
+
+                {authenticated && (
+                  <Tooltip title={privateView ? 'Make public' : 'Make private'}>
+                    <IconButton
+                      size="small"
+                      onClick={handlePrivacyChange}
+                      sx={{ ...actionBtnSx, color: privateView ? '#FF6B6B' : '#FFFFFFB3' }}
+                    >
+                      {privateView ? (
+                        <VisibilityOffIcon sx={{ fontSize: 20 }} />
+                      ) : (
+                        <VisibilityIcon sx={{ fontSize: 20 }} />
+                      )}
+                    </IconButton>
+                  </Tooltip>
+                )}
+
+                <CopyToClipboard text={`${PURL}${vid.video_id}`}>
+                  <Tooltip title="Copy link">
+                    <IconButton
+                      size="small"
+                      onMouseDown={handleMouseDown}
+                      onClick={() => setAlert({ type: 'info', message: 'Link copied to clipboard', open: true })}
+                      sx={actionBtnSx}
+                    >
+                      <LinkIcon sx={{ fontSize: 20 }} />
+                    </IconButton>
+                  </Tooltip>
+                </CopyToClipboard>
+
+                <Tooltip title="Copy timestamp">
+                  <IconButton size="small" onClick={copyTimestamp} sx={actionBtnSx}>
+                    <AccessTimeIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </Tooltip>
+
+                {authenticated && (
+                  editMode ? (
+                    <Tooltip title={updateable ? 'Save changes' : 'Done editing'}>
+                      <IconButton
+                        size="small"
+                        onClick={updateable ? update : () => setEditMode(false)}
+                        sx={{
+                          ...actionBtnSx,
+                          color: updateable ? '#3399FF' : '#FFFFFFB3',
+                          borderColor: updateable ? '#3399FF55' : '#FFFFFF1A',
+                          ...(updateable && { animation: 'blink-blue 0.5s ease-in-out infinite alternate' }),
+                        }}
+                      >
+                        <SaveIcon sx={{ fontSize: 20 }} />
+                      </IconButton>
+                    </Tooltip>
+                  ) : (
+                    <Tooltip title="Edit details">
+                      <IconButton size="small" onClick={() => setEditMode(true)} sx={actionBtnSx}>
+                        <EditIcon sx={{ fontSize: 20 }} />
+                      </IconButton>
+                    </Tooltip>
+                  )
+                )}
+              </Box>
+            </Box>
+            </Paper>
+          </Box>
         </Slide>
       </Modal>
     </>

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { Box, Button, Divider, IconButton, Modal, Paper, Slide, TextField, Tooltip, Typography } from '@mui/material'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
-import ShuffleIcon from '@mui/icons-material/Shuffle'
 import CloseIcon from '@mui/icons-material/Close'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import VisibilityIcon from '@mui/icons-material/Visibility'
@@ -431,7 +430,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                           minWidth: 0,
                           bgcolor: gamePillColor ? `rgba(${gamePillColor.join(',')}, 0.15)` : '#FFFFFF14',
                           border: `1px solid ${gamePillColor ? `rgba(${gamePillColor.join(',')}, 0.5)` : '#FFFFFF26'}`,
-                          borderRadius: '20px',
+                          borderRadius: '8px',
                           px: 1,
                           py: 0.35,
                           textDecoration: 'none',
@@ -445,7 +444,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                         {selectedGame.icon_url && (
                           <img src={selectedGame.icon_url} alt="" style={{ width: 20, height: 20, objectFit: 'contain', borderRadius: 3, flexShrink: 0 }} />
                         )}
-                        <Typography sx={{ fontSize: 11, color: '#FFFFFF', textTransform: 'uppercase', letterSpacing: '0.08em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        <Typography sx={{ fontSize: 14, color: '#FFFFFF', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                           {selectedGame.name}
                         </Typography>
                       </Box>
@@ -545,12 +544,6 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                   flexWrap: 'wrap',
                 }}
               >
-                <Tooltip title="Random video">
-                  <IconButton size="small" onClick={getRandomVideo} sx={actionBtnSx}>
-                    <ShuffleIcon sx={{ fontSize: 20 }} />
-                  </IconButton>
-                </Tooltip>
-
                 {authenticated && (
                   <Tooltip title={privateView ? 'Make public' : 'Make private'}>
                     <IconButton

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -180,9 +180,11 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   }, [])
 
   React.useEffect(() => {
+    let cancelled = false
     async function fetch() {
       try {
         const details = (await VideoService.getDetails(videoId)).data
+        if (cancelled) return
         setViewAdded(false)
         setVideo(details)
         setTitle(details.info?.title)
@@ -200,12 +202,13 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
         }
         try {
           const gameData = (await GameService.getVideoGame(videoId)).data
+          if (cancelled) return
           setSelectedGame(gameData || null)
         } catch (err) {
-          setSelectedGame(null)
+          if (!cancelled) setSelectedGame(null)
         }
       } catch (err) {
-        setAlert({ type: 'error', message: 'Unable to load video details', open: true })
+        if (!cancelled) setAlert({ type: 'error', message: 'Unable to load video details', open: true })
       }
     }
     if (videoId) {
@@ -217,6 +220,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
       setEditMode(false)
       fetch()
     }
+    return () => { cancelled = true }
   }, [videoId])
 
   const handleGameLinked = async (game) => {

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import { Box, Button, Divider, IconButton, Modal, Paper, Slide, TextField, Tooltip, Typography } from '@mui/material'
+import { Box, Button, Divider, IconButton, Modal, Paper, TextField, Tooltip, Typography } from '@mui/material'
+import { motion } from 'framer-motion'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import CloseIcon from '@mui/icons-material/Close'
@@ -267,9 +268,8 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
         {alert.message}
       </SnackbarAlert>
 
-      <Modal open={open} onClose={onClose} closeAfterTransition disableAutoFocus={true}>
-        <Slide in={open}>
-          {/* Centering wrapper — Slide animates this, click-outside closes modal */}
+      <Modal open={open} onClose={onClose} disableAutoFocus={true} slotProps={{ backdrop: { sx: { backgroundColor: 'rgba(0, 0, 0, 0.7)' } } }}>
+          {/* Centering wrapper — click-outside closes modal */}
           <Box
             tabIndex={-1}
             sx={{
@@ -283,10 +283,17 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
             }}
             onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
           >
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              style={{ display: 'flex', width: '100%', height: '100%', maxWidth: '100%', maxHeight: '100%' }}
+            >
             <Paper
               sx={{
                 borderRadius: { xs: 0, md: '12px' },
                 overflow: 'hidden',
+                boxShadow: '0 25px 60px rgba(0, 0, 0, 0.8)',
                 bgcolor: '#020D1A',
                 display: 'flex',
                 flexDirection: { xs: 'column', md: 'row' },
@@ -415,9 +422,19 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                 {/* Views + Game inline row */}
                 {!editMode && (
                   <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', mt: 0.5, gap: 2 }}>
-                    <Typography sx={{ fontSize: 14, color: '#FFFFFF55', flexShrink: 0 }}>
-                      {(vid.view_count ?? 0).toLocaleString()} {vid.view_count === 1 ? 'view' : 'views'}
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                      <Typography sx={{ fontSize: 14, color: '#FFFFFF55', flexShrink: 0 }}>
+                        {(vid.view_count ?? 0).toLocaleString()} {vid.view_count === 1 ? 'view' : 'views'}
+                      </Typography>
+                      {vid.recorded_at && (
+                        <>
+                          <Typography sx={{ fontSize: 14, color: '#FFFFFF55' }}>|</Typography>
+                          <Typography sx={{ fontSize: 14, color: '#FFFFFF55' }}>
+                            {new Date(vid.recorded_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                          </Typography>
+                        </>
+                      )}
+                    </Box>
                     {selectedGame && (
                       <Box
                         component={selectedGame.steamgriddb_id ? 'a' : 'div'}
@@ -483,7 +500,6 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                 {/* Description */}
                 {(editMode || description) && (
                   <Box>
-                    <Typography sx={labelSx}>Description</Typography>
                     {editMode ? (
                       <TextField
                         fullWidth
@@ -497,9 +513,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                         sx={inputSx}
                       />
                     ) : (
-                      <Box sx={{ bgcolor: '#FFFFFF0D', border: '1px solid #FFFFFF26', borderRadius: '8px', px: 1.5, py: 1 }}>
-                        <Typography sx={{ fontSize: 14, color: '#FFFFFFB3', lineHeight: 1.6 }}>{description}</Typography>
-                      </Box>
+                      <Typography sx={{ fontSize: 14, color: '#FFFFFF', lineHeight: 1.6 }}>{description}</Typography>
                     )}
                   </Box>
                 )}
@@ -570,19 +584,17 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                   editMode ? (
                     <Button
                       size="small"
+                      variant="outlined"
                       onClick={updateable ? update : () => setEditMode(false)}
                       sx={{
                         ml: 'auto',
                         fontSize: 12,
                         fontWeight: 400,
-                        px: 0,
-                        minWidth: 'unset',
-                        bgcolor: 'transparent',
-                        border: 'none',
                         color: updateable ? '#3399FF' : '#FFFFFF',
                         textTransform: 'uppercase',
                         letterSpacing: '0.08em',
-                        '&:hover': { bgcolor: 'transparent', color: 'white' },
+                        borderColor: updateable ? '#3399FF88' : '#FFFFFF44',
+                        '&:hover': { borderColor: updateable ? '#3399FF' : '#FFFFFF99', bgcolor: updateable ? '#3399FF11' : '#FFFFFF11' },
                         ...(updateable && { animation: 'blink-blue 0.5s ease-in-out infinite alternate' }),
                       }}
                     >
@@ -592,7 +604,8 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                     <Button
                       size="small"
                       onClick={() => setEditMode(true)}
-                      sx={{ ml: 'auto', fontSize: 12, fontWeight: 400, color: '#FFFFFF', textTransform: 'uppercase', letterSpacing: '0.08em', px: 0, minWidth: 'unset', bgcolor: 'transparent', border: 'none', '&:hover': { bgcolor: 'transparent', color: 'white' } }}
+                      variant="outlined"
+                      sx={{ ml: 'auto', fontSize: 12, fontWeight: 400, color: '#FFFFFF', textTransform: 'uppercase', letterSpacing: '0.08em', borderColor: '#FFFFFF44', borderRadius: '8px', '&:hover': { borderColor: '#FFFFFF99', bgcolor: '#FFFFFF11' } }}
                     >
                       Edit
                     </Button>
@@ -602,8 +615,8 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
               </Box>
             </Box>
             </Paper>
+            </motion.div>
           </Box>
-        </Slide>
       </Modal>
     </>
   )

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -65,7 +65,7 @@ const SIDEBAR_WIDTH = 'clamp(280px, 24vw, 420px)'
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCallback }) => {
+const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCallback, onNext, onPrev }) => {
   const [title, setTitle] = React.useState('')
   const [description, setDescription] = React.useState('')
   const [updateable, setUpdatable] = React.useState(false)
@@ -79,6 +79,17 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   const [gamePillColor, setGamePillColor] = React.useState(null)
 
   const playerRef = React.useRef()
+
+  useEffect(() => {
+    if (!open || editMode) return
+    const handler = (e) => {
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return
+      if (e.key === 'ArrowRight') onNext?.()
+      if (e.key === 'ArrowLeft') onPrev?.()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, editMode, onNext, onPrev])
 
   React.useEffect(() => {
     if (!selectedGame?.icon_url) {
@@ -141,7 +152,6 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
       }
     }
     if (videoId) {
-      setVideo(null)
       setTitle('')
       setDescription('')
       setSelectedGame(null)

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -1,19 +1,17 @@
 import React, { useEffect, useState } from 'react'
-import { Box, Divider, IconButton, Modal, Paper, Slide, TextField, Tooltip, Typography } from '@mui/material'
-import LinkIcon from '@mui/icons-material/Link'
+import { Box, Button, Divider, IconButton, Modal, Paper, Slide, TextField, Tooltip, Typography } from '@mui/material'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import ShuffleIcon from '@mui/icons-material/Shuffle'
-import SaveIcon from '@mui/icons-material/Save'
 import CloseIcon from '@mui/icons-material/Close'
-import EditIcon from '@mui/icons-material/Edit'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import VisibilityIcon from '@mui/icons-material/Visibility'
-import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { copyToClipboard, getPublicWatchUrl, getServedBy, getUrl, getVideoSources, getSetting } from '../../common/utils'
 import { ConfigService, VideoService, GameService } from '../../services'
 import SnackbarAlert from '../alert/SnackbarAlert'
 import VideoJSPlayer from '../misc/VideoJSPlayer'
 import GameSearch from '../game/GameSearch'
+import { FastAverageColor } from 'fast-average-color'
 
 const URL = getUrl()
 const PURL = getPublicWatchUrl()
@@ -78,8 +76,20 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
   const [autoplay, setAutoplay] = useState(false)
   const [selectedGame, setSelectedGame] = React.useState(null)
   const [editMode, setEditMode] = React.useState(false)
+  const [gamePillColor, setGamePillColor] = React.useState(null)
 
   const playerRef = React.useRef()
+
+  React.useEffect(() => {
+    if (!selectedGame?.icon_url) {
+      setGamePillColor(null)
+      return
+    }
+    const fac = new FastAverageColor()
+    fac.getColorAsync(selectedGame.icon_url, { crossOrigin: 'anonymous', algorithm: 'dominant' })
+      .then((color) => setGamePillColor(color.value.slice(0, 3)))
+      .catch(() => setGamePillColor(null))
+  }, [selectedGame?.icon_url])
 
   const getRandomVideo = async () => {
     try {
@@ -364,11 +374,11 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                   flex: 1,
                   overflowY: 'auto',
                   px: 2.5,
-                  pt: 2.5,
+                  pt: 2,
                   pb: 2,
                   display: 'flex',
                   flexDirection: 'column',
-                  gap: 2.5,
+                  gap: 2,
                   '&::-webkit-scrollbar': { width: 4 },
                   '&::-webkit-scrollbar-track': { bgcolor: 'transparent' },
                   '&::-webkit-scrollbar-thumb': { bgcolor: '#FFFFFF26', borderRadius: 2 },
@@ -389,69 +399,71 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                       sx={inputSx}
                     />
                   ) : (
-                    <Typography sx={{ fontWeight: 700, fontSize: 17, color: 'white', lineHeight: 1.4 }}>
+                    <Typography sx={{ fontWeight: 900, fontSize: 21, color: 'white', lineHeight: 1.3, letterSpacing: '-0.03em' }}>
                       {title || 'Untitled'}
                     </Typography>
                   )}
+                {/* Views + Game inline row */}
+                {!editMode && (
+                  <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', mt: 0.5, gap: 2 }}>
+                    <Typography sx={{ fontSize: 14, color: '#FFFFFF55', flexShrink: 0 }}>
+                      {(vid.view_count ?? 0).toLocaleString()} {vid.view_count === 1 ? 'view' : 'views'}
+                    </Typography>
+                    {selectedGame && (
+                      <Box
+                        component={selectedGame.steamgriddb_id ? 'a' : 'div'}
+                        href={selectedGame.steamgriddb_id ? `#/games/${selectedGame.steamgriddb_id}` : undefined}
+                        onClick={selectedGame.steamgriddb_id ? (e) => e.stopPropagation() : undefined}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 0.75,
+                          minWidth: 0,
+                          bgcolor: gamePillColor ? `rgba(${gamePillColor.join(',')}, 0.15)` : '#FFFFFF14',
+                          border: `1px solid ${gamePillColor ? `rgba(${gamePillColor.join(',')}, 0.5)` : '#FFFFFF26'}`,
+                          borderRadius: '20px',
+                          px: 1,
+                          py: 0.35,
+                          textDecoration: 'none',
+                          flexShrink: 0,
+                          ...(selectedGame.steamgriddb_id && {
+                            cursor: 'pointer',
+                            '&:hover': { bgcolor: gamePillColor ? `rgba(${gamePillColor.join(',')}, 0.4)` : '#FFFFFF22' },
+                          }),
+                        }}
+                      >
+                        {selectedGame.icon_url && (
+                          <img src={selectedGame.icon_url} alt="" style={{ width: 20, height: 20, objectFit: 'contain', borderRadius: 3, flexShrink: 0 }} />
+                        )}
+                        <Typography sx={{ fontSize: 11, color: '#FFFFFF', textTransform: 'uppercase', letterSpacing: '0.08em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {selectedGame.name}
+                        </Typography>
+                      </Box>
+                    )}
+                  </Box>
+                )}
                 </Box>
 
-                {/* Game */}
-                {(selectedGame || (editMode && (authenticated || getSetting('ui_config')?.allow_public_game_tag))) && (
+                {/* Game search (edit mode only) */}
+                {editMode && (authenticated || getSetting('ui_config')?.allow_public_game_tag) && (
                   <Box>
                     {selectedGame ? (
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, bgcolor: '#FFFFFF0D', border: '1px solid #FFFFFF26', borderRadius: '8px', px: 1.5, py: 1 }}>
                         {selectedGame.icon_url && (
-                          <img
-                            src={selectedGame.icon_url}
-                            alt=""
-                            style={{ width: 20, height: 20, objectFit: 'contain', borderRadius: 3, flexShrink: 0 }}
-                          />
+                          <img src={selectedGame.icon_url} alt="" style={{ width: 20, height: 20, objectFit: 'contain', borderRadius: 3, flexShrink: 0 }} />
                         )}
-                        <Typography
-                          component={selectedGame.steamgriddb_id ? 'a' : 'span'}
-                          href={selectedGame.steamgriddb_id ? `#/games/${selectedGame.steamgriddb_id}` : undefined}
-                          onClick={selectedGame.steamgriddb_id ? (e) => e.stopPropagation() : undefined}
-                          sx={{
-                            fontSize: 13,
-                            color: '#FFFFFFB3',
-                            textTransform: 'uppercase',
-                            letterSpacing: '0.08em',
-                            flex: 1,
-                            textDecoration: 'none',
-                            ...(selectedGame.steamgriddb_id && {
-                              cursor: 'pointer',
-                              '&:hover': { color: '#3399FF', textDecoration: 'underline' },
-                            }),
-                          }}
-                        >
+                        <Typography sx={{ fontSize: 13, color: '#FFFFFFB3', textTransform: 'uppercase', letterSpacing: '0.08em', flex: 1 }}>
                           {selectedGame.name}
                         </Typography>
-                        {editMode && (
-                          <IconButton
-                            size="small"
-                            onClick={handleUnlinkGame}
-                            sx={{ color: '#FFFFFF66', '&:hover': { color: 'white' }, p: 0.25 }}
-                          >
-                            <CloseIcon sx={{ fontSize: 16 }} />
-                          </IconButton>
-                        )}
+                        <IconButton size="small" onClick={handleUnlinkGame} sx={{ color: '#FFFFFF66', '&:hover': { color: 'white' }, p: 0.25 }}>
+                          <CloseIcon sx={{ fontSize: 16 }} />
+                        </IconButton>
                       </Box>
                     ) : (
-                      <Box
-                        sx={{
-                          ...rowBoxSx,
-                          py: 0,
-                          overflow: 'hidden',
-                          '& .MuiInputBase-root': { color: 'white', px: 0 },
-                          '& input::placeholder': { color: '#FFFFFF66', opacity: 1 },
-                          '& .MuiSvgIcon-root': { color: '#FFFFFF66' },
-                        }}
-                      >
+                      <Box sx={{ ...rowBoxSx, py: 0, overflow: 'hidden', '& .MuiInputBase-root': { color: 'white', px: 0 }, '& input::placeholder': { color: '#FFFFFF66', opacity: 1 }, '& .MuiSvgIcon-root': { color: '#FFFFFF66' } }}>
                         <GameSearch
                           onGameLinked={handleGameLinked}
-                          onError={(err) =>
-                            setAlert({ open: true, type: 'error', message: err.response?.data || 'Error linking game' })
-                          }
+                          onError={(err) => setAlert({ open: true, type: 'error', message: err.response?.data || 'Error linking game' })}
                           placeholder="Search for a game..."
                         />
                       </Box>
@@ -482,6 +494,29 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                     )}
                   </Box>
                 )}
+
+                {/* Share link */}
+                <Box>
+                  <Typography sx={labelSx}>Share</Typography>
+                  <Box sx={{ ...rowBoxSx, gap: 0.5 }}>
+                    <Typography sx={{ flex: 1, fontSize: 12, color: '#FFFFFF66', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontFamily: 'monospace' }}>
+                      {`${PURL}${vid.video_id}`}
+                    </Typography>
+                    <Tooltip title="Copy link">
+                      <IconButton
+                        size="small"
+                        onMouseDown={handleMouseDown}
+                        onClick={() => {
+                          copyToClipboard(`${PURL}${vid.video_id}`)
+                          setAlert({ type: 'info', message: 'Link copied to clipboard', open: true })
+                        }}
+                        sx={{ color: '#FFFFFF66', '&:hover': { color: 'white' }, p: 0.5, flexShrink: 0 }}
+                      >
+                        <ContentCopyIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                </Box>
 
                 {/* Spacer — future "Related Videos" will live here */}
                 <Box sx={{ flex: 1 }} />
@@ -522,20 +557,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                   </Tooltip>
                 )}
 
-                <CopyToClipboard text={`${PURL}${vid.video_id}`}>
-                  <Tooltip title="Copy link">
-                    <IconButton
-                      size="small"
-                      onMouseDown={handleMouseDown}
-                      onClick={() => setAlert({ type: 'info', message: 'Link copied to clipboard', open: true })}
-                      sx={actionBtnSx}
-                    >
-                      <LinkIcon sx={{ fontSize: 20 }} />
-                    </IconButton>
-                  </Tooltip>
-                </CopyToClipboard>
-
-                <Tooltip title="Copy timestamp">
+<Tooltip title="Copy timestamp">
                   <IconButton size="small" onClick={copyTimestamp} sx={actionBtnSx}>
                     <AccessTimeIcon sx={{ fontSize: 20 }} />
                   </IconButton>
@@ -543,28 +565,37 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
 
                 {authenticated && (
                   editMode ? (
-                    <Tooltip title={updateable ? 'Save changes' : 'Done editing'}>
-                      <IconButton
-                        size="small"
-                        onClick={updateable ? update : () => setEditMode(false)}
-                        sx={{
-                          ...actionBtnSx,
-                          color: updateable ? '#3399FF' : '#FFFFFFB3',
-                          borderColor: updateable ? '#3399FF55' : '#FFFFFF1A',
-                          ...(updateable && { animation: 'blink-blue 0.5s ease-in-out infinite alternate' }),
-                        }}
-                      >
-                        <SaveIcon sx={{ fontSize: 20 }} />
-                      </IconButton>
-                    </Tooltip>
+                    <Button
+                      size="small"
+                      onClick={updateable ? update : () => setEditMode(false)}
+                      sx={{
+                        ml: 'auto',
+                        fontSize: 12,
+                        fontWeight: 400,
+                        px: 0,
+                        minWidth: 'unset',
+                        bgcolor: 'transparent',
+                        border: 'none',
+                        color: updateable ? '#3399FF' : '#FFFFFF',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em',
+                        '&:hover': { bgcolor: 'transparent', color: 'white' },
+                        ...(updateable && { animation: 'blink-blue 0.5s ease-in-out infinite alternate' }),
+                      }}
+                    >
+                      Save
+                    </Button>
                   ) : (
-                    <Tooltip title="Edit details">
-                      <IconButton size="small" onClick={() => setEditMode(true)} sx={actionBtnSx}>
-                        <EditIcon sx={{ fontSize: 20 }} />
-                      </IconButton>
-                    </Tooltip>
+                    <Button
+                      size="small"
+                      onClick={() => setEditMode(true)}
+                      sx={{ ml: 'auto', fontSize: 12, fontWeight: 400, color: '#FFFFFF', textTransform: 'uppercase', letterSpacing: '0.08em', px: 0, minWidth: 'unset', bgcolor: 'transparent', border: 'none', '&:hover': { bgcolor: 'transparent', color: 'white' } }}
+                    >
+                      Edit
+                    </Button>
                   )
                 )}
+
               </Box>
             </Box>
             </Paper>

--- a/app/client/src/views/Feed.js
+++ b/app/client/src/views/Feed.js
@@ -183,7 +183,7 @@ const Feed = ({ authenticated, searchText, cardSize, listStyle }) => {
                 />
               )}
               {listStyle === 'card' && (
-                <Box sx={{ px: 1 }}>
+                <Box>
                   {loading && <LoadingSpinner />}
                   {!loading && (
                     <VideoCards

--- a/app/client/src/views/Watch.js
+++ b/app/client/src/views/Watch.js
@@ -31,36 +31,7 @@ const Watch = ({ authenticated }) => {
   const [viewAdded, setViewAdded] = React.useState(false)
 
   const videoPlayerRef = useRef(null)
-  const videoContainerRef = React.useRef(null)
   const [alert, setAlert] = React.useState({ open: false })
-  
-  React.useEffect(() => {
-    const container = videoContainerRef.current
-    if (!container) return
-
-    const aspectRatio = (details?.info?.width && details?.info?.height)
-      ? details.info.width / details.info.height
-      : 16 / 9
-
-    const computeSize = () => {
-      const availW = container.clientWidth
-      const availH = container.clientHeight
-      if (availW <= 0 || availH <= 0) return
-
-      let w = availW
-      let h = w / aspectRatio
-
-      if (h > availH) {
-        h = availH
-        w = h * aspectRatio
-      }
-    }
-
-    const observer = new ResizeObserver(computeSize)
-    observer.observe(container)
-
-    return () => observer.disconnect()
-  }, [details?.info?.width, details?.info?.height])
 
   React.useEffect(() => {
     async function fetch() {
@@ -218,19 +189,17 @@ const Watch = ({ authenticated }) => {
         <meta property="og:video:height" value={details?.info?.height} />
         <meta property="og:site_name" value="Fireshare" />
       </Helmet>
-      <div style={{ display: 'flex', height: '100%', flexDirection: 'column', alignItems: 'start' }}>
-        <div ref={videoContainerRef} style={{ flex: '1 1 auto', minHeight: 0, width: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center', paddingLeft: 8, paddingRight: 8 }}>
+      <div style={{ display: 'flex', height: 'calc(100vh - 64px)', flexDirection: 'column' }}>
+        <div style={{ flex: '1 1 auto', minHeight: 0, width: '100%', position: 'relative', backgroundColor: '#000' }}>
           <VideoJSPlayer
             sources={getVideoSources(id, details?.info, details?.extension || '.mp4')}
             poster={getPosterUrl()}
             autoplay={true}
             controls={true}
             onTimeUpdate={handleTimeUpdate}
-            onReady={(player) => {
-              videoPlayerRef.current = player
-            }}
+            onReady={(player) => { videoPlayerRef.current = player }}
             startTime={time ? parseFloat(time) : 0}
-            style={{ backgroundColor: '#000' }}
+            style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
             fluid={false}
             fill={true}
           />

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -699,24 +699,75 @@ def transcode_videos(regenerate, video, include_corrupt):
                 logger.info(f"Skipping {skipped_count} video(s) previously marked as corrupt. Use --include-corrupt to retry them.")
 
         # Build work queue: list of (video_info, height) tuples that actually need transcoding
+        # Also reconcile has_* flags if outputs already exist on disk.
         work_items = []
+        skipped_missing_source = 0
+        skipped_source_too_small = 0
+        skipped_existing_output = 0
+        reconciled_flag_updates = 0
+        reconciled_videos = set()
         for vi in vinfos:
             video_path = Path(processed_root, "video_links", vi.video_id + vi.video.extension)
             if not video_path.exists():
+                skipped_missing_source += 1
+                if video:
+                    logger.warning(f"Skipping video {vi.video_id}: source file not found at {video_path}")
                 continue
             derived_path = Path(processed_root, "derived", vi.video_id)
             original_height = vi.height or 0
             for height in resolutions:
                 if original_height > 0 and original_height <= height:
+                    skipped_source_too_small += 1
+                    if video:
+                        logger.info(
+                            f"Skipping {vi.video_id} {height}p: source height ({original_height}p) "
+                            f"is not greater than target"
+                        )
                     continue
                 transcode_path = derived_path / f"{vi.video_id}-{height}p.mp4"
-                if not transcode_path.exists() or regenerate:
-                    work_items.append((vi, height, video_path, derived_path, transcode_path))
+                has_attr = f'has_{height}p'
+                output_exists = transcode_path.exists()
+
+                if output_exists and getattr(vi, has_attr, False) is not True:
+                    setattr(vi, has_attr, True)
+                    reconciled_flag_updates += 1
+                    reconciled_videos.add(vi.video_id)
+                    if video:
+                        logger.info(f"Detected existing {height}p output on disk; updating {has_attr}=True for {vi.video_id}")
+
+                if output_exists and not regenerate:
+                    skipped_existing_output += 1
+                    if video:
+                        logger.info(f"Skipping {vi.video_id} {height}p: output already exists at {transcode_path}")
+                    continue
+
+                work_items.append((vi, height, video_path, derived_path, transcode_path))
+
+        if reconciled_flag_updates > 0:
+            db.session.commit()
+            logger.info(
+                f"Reconciled transcode flags from disk for {len(reconciled_videos)} video(s), "
+                f"updated {reconciled_flag_updates} flag value(s)."
+            )
 
         total_jobs = len(work_items)
         logger.info(f'Processing {total_jobs:,} transcode job(s) (GPU: {use_gpu}, Encoder: {encoder_preference})')
 
         if total_jobs == 0:
+            if video:
+                vi = vinfos[0] if vinfos else None
+                logger.info(
+                    f"Single-video planner summary for {video}: "
+                    f"found_video_info={bool(vi)}, source_height={vi.height if vi else None}, "
+                    f"enabled_targets={','.join(f'{h}p' for h in resolutions) if resolutions else 'none'}, "
+                    f"regenerate={regenerate}, include_corrupt={include_corrupt}"
+                )
+                logger.info(
+                    "Single-video planner breakdown: "
+                    f"missing_source={skipped_missing_source}, "
+                    f"source_too_small={skipped_source_too_small}, "
+                    f"already_exists={skipped_existing_output}"
+                )
             logger.info("No videos need transcoding")
             util.clear_transcoding_status(paths['data'])
             return


### PR DESCRIPTION
• The VideoModal.js has been completely redesigned from the ground up, with better scaling, more options to edit video info, and a refreshed mobile version. This new scaling setup now bases the info window on the height of the video, meaning there are no more black bars showing, no matter what the aspect ratio is.
<img width="1920" height="926" alt="Screenshot 2026-03-10 at 8 18 57 PM" src="https://github.com/user-attachments/assets/c3fe0b99-5ada-46ce-8e6b-cdad4f0c7010" />



• Added Arrow keys navigation to the video modal. Users can use the left and right arrow keys to scroll through the videos in their feeds. 
• Added logging to transcoding errors, so if a transcode fails, we have information as to why.


This'll start matching with the rest of the new design language, I can't wait to see what people think :) 
