### PR TITLE
Styling adjustments to Games page, Share page, Settings page

### DIFF
--- a/app/client/src/common/reactSelectFolderTheme.js
+++ b/app/client/src/common/reactSelectFolderTheme.js
@@ -1,48 +1,63 @@
 const selectTheme = {
   control: (styles) => ({
     ...styles,
-    backgroundColor: '#001E3C',
-    borderColor: '#2684FF',
+    backgroundColor: '#FFFFFF0D',
+    borderColor: '#FFFFFF26',
+    borderRadius: '8px',
+    boxShadow: 'none',
     '&:hover': {
-      borderColor: '#2684FF',
+      borderColor: '#FFFFFF55',
     },
     color: '#fff',
+    fontSize: 14,
+    fontFamily: 'Inter, sans-serif',
   }),
   menu: (styles) => ({
     ...styles,
-    borderRadius: 0,
-    marginTop: 0,
-    backgroundColor: '#001E3C',
-    '&:hover': {
-      borderColor: '#2684FF',
-    },
+    borderRadius: '8px',
+    marginTop: 4,
+    backgroundColor: '#0b132b',
+    border: '1px solid #FFFFFF1A',
+    boxShadow: '0 8px 24px #00000066',
   }),
   menuList: (styles) => ({
     ...styles,
-    backgroundColor: '#001E3C',
-    padding: 0,
+    backgroundColor: 'transparent',
+    padding: 4,
   }),
   singleValue: (styles) => ({
     ...styles,
     color: '#fff',
+    fontSize: 14,
+    fontFamily: 'Inter, sans-serif',
   }),
-  option: (styles, { data, isDisabled, isFocused, isSelected }) => {
-    return {
-      backgroundColor: '#003366',
-      boxSizing: 'border-box',
-      display: 'block',
-      fontSize: 'inherit',
-      label: 'option',
-      padding: '8px 12px',
-      userSelect: 'none',
-      width: '100%',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-      '&:hover': {
-        backgroundColor: '#3399FF',
-      },
-    }
-  },
+  placeholder: (styles) => ({
+    ...styles,
+    color: '#FFFFFF66',
+    fontSize: 14,
+    fontFamily: 'Inter, sans-serif',
+  }),
+  dropdownIndicator: (styles) => ({
+    ...styles,
+    color: '#FFFFFF66',
+    '&:hover': { color: '#fff' },
+  }),
+  indicatorSeparator: () => ({ display: 'none' }),
+  option: (styles, { isFocused, isSelected }) => ({
+    ...styles,
+    backgroundColor: isSelected ? '#3399FF26' : isFocused ? '#FFFFFF1A' : 'transparent',
+    borderRadius: '6px',
+    color: isSelected ? '#fff' : '#FFFFFFCC',
+    fontSize: 14,
+    fontFamily: 'Inter, sans-serif',
+    padding: '8px 10px',
+    cursor: 'pointer',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    '&:active': {
+      backgroundColor: '#FFFFFF26',
+    },
+  }),
 }
 export default selectTheme

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -21,7 +21,6 @@ import { ConfigService, VideoService, GameService } from '../../services'
 import SnackbarAlert from '../alert/SnackbarAlert'
 import VideoJSPlayer from '../misc/VideoJSPlayer'
 import GameSearch from '../game/GameSearch'
-import { FastAverageColor } from 'fast-average-color'
 
 const URL = getUrl()
 const PURL = getPublicWatchUrl()
@@ -188,11 +187,51 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
       setGamePillColor(null)
       return
     }
-    const fac = new FastAverageColor()
-    fac
-      .getColorAsync(selectedGame.icon_url, { crossOrigin: 'anonymous', algorithm: 'dominant' })
-      .then((color) => setGamePillColor(color.value.slice(0, 3)))
-      .catch(() => setGamePillColor(null))
+
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+
+    img.onload = () => {
+      const SIZE = 64
+      const canvas = document.createElement('canvas')
+      canvas.width = SIZE
+      canvas.height = SIZE
+      const ctx = canvas.getContext('2d')
+      ctx.drawImage(img, 0, 0, SIZE, SIZE)
+
+      const { data } = ctx.getImageData(0, 0, SIZE, SIZE)
+      let bestColor = null
+      let bestSaturation = -1
+
+      for (let i = 0; i < data.length; i += 4) {
+        const alpha = data[i + 3]
+        if (alpha < 128) continue
+
+        const r = data[i] / 255
+        const g = data[i + 1] / 255
+        const b = data[i + 2] / 255
+
+        const max = Math.max(r, g, b)
+        const min = Math.min(r, g, b)
+        const lightness = (max + min) / 2
+
+        // Skip near-black and near-white pixels
+        if (lightness < 0.15 || lightness > 0.92) continue
+
+        const chroma = max - min
+        const saturation = chroma === 0 ? 0 : chroma / (1 - Math.abs(2 * lightness - 1))
+
+        if (saturation > bestSaturation) {
+          bestSaturation = saturation
+          bestColor = [data[i], data[i + 1], data[i + 2]]
+        }
+      }
+
+      setGamePillColor(bestSaturation > 0.2 ? bestColor : null)
+    }
+
+    img.onerror = () => setGamePillColor(null)
+    img.src = selectedGame.icon_url
   }, [selectedGame?.icon_url])
 
   const getRandomVideo = async () => {

--- a/app/client/src/components/nav/Navbar20.js
+++ b/app/client/src/components/nav/Navbar20.js
@@ -363,7 +363,7 @@ function Navbar20({
         })}
       </List>
       {/* Folder selector — hidden on mobile (xs) */}
-      {(page === '/' || page === '/feed') && open && !isMobile && folders.length > 1 && (
+      {(page === '/' || page === '/feed') && open && !isMobile && folders.length > 1 && uiConfig.show_folder_dropdown === true && (
         <>
           <Divider />
           <Box sx={{ p: open ? 1.5 : 0.75 }}>
@@ -386,9 +386,9 @@ function Navbar20({
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    border: '1px solid #2684FF',
-                    borderRadius: '4px',
-                    backgroundColor: '#001E3C',
+                    border: '1px solid #FFFFFF26',
+                    borderRadius: '8px',
+                    backgroundColor: '#FFFFFF0D',
                     cursor: 'pointer',
                     color: '#fff',
                     fontSize: 11,

--- a/app/client/src/views/Games.js
+++ b/app/client/src/views/Games.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { motion } from 'framer-motion'
 import {
   Box,
   Grid,
@@ -26,8 +27,6 @@ import LoadingSpinner from '../components/misc/LoadingSpinner'
 const Games = ({ authenticated, searchText }) => {
   const [games, setGames] = React.useState([])
   const [loading, setLoading] = React.useState(true)
-  const [hoveredGame, setHoveredGame] = React.useState(null)
-  const [mousePos, setMousePos] = React.useState({ x: 0, y: 0 })
   const [editMode, setEditMode] = React.useState(false)
   const [selectedGames, setSelectedGames] = React.useState(new Set())
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
@@ -67,18 +66,6 @@ const Games = ({ authenticated, searchText }) => {
     }
   }, [editMode, isMdDown])
 
-  const handleMouseMove = (e, gameId) => {
-    const rect = e.currentTarget.getBoundingClientRect()
-    const x = (e.clientX - rect.left) / rect.width - 0.5
-    const y = (e.clientY - rect.top) / rect.height - 0.5
-    setMousePos({ x, y })
-    setHoveredGame(gameId)
-  }
-
-  const handleMouseLeave = () => {
-    setHoveredGame(null)
-    setMousePos({ x: 0, y: 0 })
-  }
 
   const handleEditModeToggle = () => {
     setEditMode(!editMode)
@@ -198,34 +185,30 @@ const Games = ({ authenticated, searchText }) => {
       <Grid container spacing={2}>
         {[...filteredGames]
           .sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' }))
-          .map((game) => {
-            const isHovered = hoveredGame === game.steamgriddb_id
-            const heroTransform = isHovered
-              ? `translate(${mousePos.x * -15}px, ${mousePos.y * -15}px) scale(1.1)`
-              : 'translate(0, 0) scale(1)'
-            const logoTransform = isHovered
-              ? `translate(calc(-50% + ${mousePos.x * 8}px), calc(-50% + ${mousePos.y * 8}px)) scale(1.05)`
-              : 'translate(-50%, -50%) scale(1)'
-
+          .map((game, index) => {
             const isSelected = selectedGames.has(game.steamgriddb_id)
 
             return (
               <Grid item xs={12} sm={6} md={4} key={game.id}>
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.3, delay: index * 0.05 }}
+                >
                 <Box
                   onClick={() => handleGameClick(game.steamgriddb_id)}
-                  onMouseMove={(e) => handleMouseMove(e, game.steamgriddb_id)}
-                  onMouseLeave={handleMouseLeave}
                   sx={{
                     position: 'relative',
                     height: 170,
                     borderRadius: 2,
                     overflow: 'hidden',
                     cursor: 'pointer',
-                    transition: 'box-shadow 0.3s ease, border 0.3s ease',
+                    transition: 'transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease',
                     border: isSelected ? '3px solid' : '3px solid transparent',
                     borderColor: isSelected ? 'primary.main' : 'transparent',
                     '&:hover': {
-                      boxShadow: '0 0 20px rgba(255, 255, 255, 0.5)',
+                      transform: 'scale(1.04)',
+                      boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
                     },
                   }}
                 >
@@ -261,8 +244,6 @@ const Games = ({ authenticated, searchText }) => {
                         height: '100%',
                         objectFit: 'cover',
                         position: 'absolute',
-                        transform: heroTransform,
-                        transition: 'transform 0.2s ease-out',
                         filter: 'brightness(0.7)',
                       }}
                     />
@@ -275,16 +256,16 @@ const Games = ({ authenticated, searchText }) => {
                         position: 'absolute',
                         top: '50%',
                         left: '50%',
-                        transform: logoTransform,
+                        transform: 'translate(-50%, -50%)',
                         maxWidth: '65%',
                         maxHeight: '65%',
                         objectFit: 'contain',
                         zIndex: 1,
-                        transition: 'transform 0.2s ease-out',
                       }}
                     />
                   )}
                 </Box>
+                </motion.div>
               </Grid>
             )
           })}

--- a/app/client/src/views/Settings.js
+++ b/app/client/src/views/Settings.js
@@ -34,6 +34,7 @@ import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import StopIcon from '@mui/icons-material/Stop'
 import { ConfigService, VideoService, GameService } from '../services'
+import { setSetting } from '../common/utils'
 import LightTooltip from '../components/misc/LightTooltip'
 import GameSearch from '../components/game/GameSearch'
 
@@ -115,6 +116,7 @@ const Settings = () => {
       await ConfigService.updateConfig(updatedConfig)
       setUpdateable(false)
       setConfig(_.cloneDeep(updatedConfig))
+      setSetting('ui_config', updatedConfig.ui_config)
       setAlert({ open: true, message: 'Settings Updated! Changes may take a minute to take effect.', type: 'success' })
     } catch (err) {
       console.error(err)
@@ -499,6 +501,20 @@ const Settings = () => {
                     />
                   }
                   label="Games"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={updatedConfig.ui_config?.show_folder_dropdown === true}
+                      onChange={(e) =>
+                        setUpdatedConfig((prev) => ({
+                          ...prev,
+                          ui_config: { ...prev.ui_config, show_folder_dropdown: e.target.checked },
+                        }))
+                      }
+                    />
+                  }
+                  label="Folder Dropdown"
                 />
               </Stack>
             )}

--- a/app/client/src/views/Settings.js
+++ b/app/client/src/views/Settings.js
@@ -92,6 +92,14 @@ const Settings = () => {
   }, [])
 
   React.useEffect(() => {
+    if (activeTab === 4) {
+      GameService.getFolderRules()
+        .then((res) => setFolderRules(res.data))
+        .catch((err) => console.error(err))
+    }
+  }, [activeTab])
+
+  React.useEffect(() => {
     if (config && updatedConfig) {
       setUpdateable(!_.isEqual(config, updatedConfig))
     }
@@ -307,7 +315,6 @@ const Settings = () => {
           <Tab label="Sidebar" />
           <Tab label="Integrations" />
           <Tab label="Transcoding" />
-          <Tab label="Feeds" />
           <Tab label="Folders" />
           <Tab label="Actions" />
         </Tabs>
@@ -583,6 +590,40 @@ const Settings = () => {
                     ),
                   }}
                 />
+                <Divider />
+                <TextField
+                  size="small"
+                  label="RSS Feed Title"
+                  value={updatedConfig.rss_config?.title || ''}
+                  onChange={(e) =>
+                    setUpdatedConfig((prev) => ({
+                      ...prev,
+                      rss_config: { ...(prev.rss_config || {}), title: e.target.value },
+                    }))
+                  }
+                />
+                <TextField
+                  size="small"
+                  label="RSS Feed Description"
+                  multiline
+                  rows={2}
+                  value={updatedConfig.rss_config?.description || ''}
+                  onChange={(e) =>
+                    setUpdatedConfig((prev) => ({
+                      ...prev,
+                      rss_config: { ...(prev.rss_config || {}), description: e.target.value },
+                    }))
+                  }
+                />
+                <Button
+                  variant="outlined"
+                  startIcon={<RssFeedIcon />}
+                  fullWidth
+                  onClick={handleCopyRssFeedUrl}
+                  sx={{ borderColor: 'rgba(255, 255, 255, 0.23)', color: '#fff' }}
+                >
+                  Copy RSS Feed URL
+                </Button>
               </Stack>
             )}
 
@@ -728,47 +769,9 @@ const Settings = () => {
               </Stack>
             )}
 
-            {/* Feeds */}
-            {activeTab === 4 && (
-              <Stack spacing={2} sx={{ maxWidth: 500, pt: 2 }}>
-                <TextField
-                  size="small"
-                  label="RSS Feed Title"
-                  value={updatedConfig.rss_config?.title || ''}
-                  onChange={(e) =>
-                    setUpdatedConfig((prev) => ({
-                      ...prev,
-                      rss_config: { ...(prev.rss_config || {}), title: e.target.value },
-                    }))
-                  }
-                />
-                <TextField
-                  size="small"
-                  label="RSS Feed Description"
-                  multiline
-                  rows={2}
-                  value={updatedConfig.rss_config?.description || ''}
-                  onChange={(e) =>
-                    setUpdatedConfig((prev) => ({
-                      ...prev,
-                      rss_config: { ...(prev.rss_config || {}), description: e.target.value },
-                    }))
-                  }
-                />
-                <Button
-                  variant="outlined"
-                  startIcon={<RssFeedIcon />}
-                  fullWidth
-                  onClick={handleCopyRssFeedUrl}
-                  sx={{ borderColor: 'rgba(255, 255, 255, 0.23)', color: '#fff' }}
-                >
-                  Copy RSS Feed URL
-                </Button>
-              </Stack>
-            )}
 
             {/* Folders */}
-            {activeTab === 5 && (
+            {activeTab === 4 && (
               <Stack spacing={2} sx={{ maxWidth: 500 }}>
                 <Box sx={{ textAlign: 'center' }}>
                   <Typography variant="overline" sx={{ fontWeight: 700, fontSize: 18 }}>
@@ -897,7 +900,7 @@ const Settings = () => {
             )}
 
             {/* Actions */}
-            {activeTab === 6 && (
+            {activeTab === 5 && (
               <Stack spacing={2} sx={{ maxWidth: 500, pt: 2 }}>
                 <Button
                   variant="contained"
@@ -931,7 +934,7 @@ const Settings = () => {
           </Box>
 
           {/* Save button pinned to bottom */}
-          {activeTab !== 5 && activeTab !== 6 && activeTab !== 7 && (
+          {activeTab !== 4 && activeTab !== 5 && activeTab !== 6 && (
             <Box sx={{ pt: 2, maxWidth: 500, flexShrink: 0 }}>
               <Divider sx={{ mb: 2 }} />
               <Button

--- a/app/client/src/views/Settings.js
+++ b/app/client/src/views/Settings.js
@@ -768,7 +768,7 @@ const Settings = () => {
                     No folders found.
                   </Typography>
                 ) : (
-                  <Box sx={{ maxHeight: 500, overflowY: 'auto', pr: 1 }}>
+                  <Box sx={{ maxHeight: 800, overflowY: 'auto', pr: 1 }}>
                     <Stack spacing={1}>
                       {folderRules.map((item) => (
                         <Box
@@ -778,16 +778,16 @@ const Settings = () => {
                             alignItems: 'center',
                             justifyContent: 'space-between',
                             p: 1.5,
-                            borderRadius: 2,
-                            background: 'rgba(255, 255, 255, 0.05)',
+                            borderRadius: '8px',
+                            bgcolor: '#FFFFFF0D',
                           }}
                         >
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flex: 1 }}>
-                            <FolderIcon sx={{ color: 'rgba(255, 255, 255, 0.7)' }} />
+                            <FolderIcon sx={{ color: '#FFFFFF66' }} />
                             <Box sx={{ flex: 1 }}>
-                              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                              <Typography sx={{ fontSize: 14, fontWeight: 600, color: 'white' }}>
                                 {item.folder_path}
-                                <Typography component="span" variant="caption" sx={{ ml: 1, color: 'text.secondary' }}>
+                                <Typography component="span" sx={{ fontSize: 12, ml: 1, color: '#FFFFFF55' }}>
                                   ({item.video_count} videos)
                                 </Typography>
                               </Typography>
@@ -805,16 +805,16 @@ const Settings = () => {
                                   <IconButton
                                     size="small"
                                     onClick={() => setEditingFolder(null)}
-                                    sx={{ color: 'rgba(255, 255, 255, 0.5)' }}
+                                    sx={{ color: '#FFFFFF66' }}
                                   >
                                     <CloseIcon fontSize="small" />
                                   </IconButton>
                                 </Box>
                               ) : item.rule ? (
                                 <Typography
-                                  variant="caption"
                                   sx={{
-                                    color: 'primary.main',
+                                    fontSize: 12,
+                                    color: '#3399FF',
                                     cursor: 'pointer',
                                     '&:hover': { textDecoration: 'underline' },
                                   }}
@@ -824,9 +824,9 @@ const Settings = () => {
                                 </Typography>
                               ) : item.suggested_game ? (
                                 <Typography
-                                  variant="caption"
                                   sx={{
-                                    color: 'warning.main',
+                                    fontSize: 12,
+                                    color: '#FFB74D',
                                     cursor: 'pointer',
                                     '&:hover': { textDecoration: 'underline' },
                                   }}
@@ -836,9 +836,9 @@ const Settings = () => {
                                 </Typography>
                               ) : (
                                 <Typography
-                                  variant="caption"
                                   sx={{
-                                    color: 'text.secondary',
+                                    fontSize: 12,
+                                    color: '#FFFFFF55',
                                     cursor: 'pointer',
                                     '&:hover': { textDecoration: 'underline' },
                                   }}
@@ -856,7 +856,7 @@ const Settings = () => {
                                 setDeleteMenuAnchor(e.currentTarget)
                                 setDeleteMenuRuleId(item.rule.id)
                               }}
-                              sx={{ color: 'rgba(255, 255, 255, 0.5)' }}
+                              sx={{ color: '#FFFFFF66' }}
                             >
                               <MoreVertIcon fontSize="small" />
                             </IconButton>
@@ -915,7 +915,7 @@ const Settings = () => {
           </Box>
 
           {/* Save button pinned to bottom */}
-          {activeTab !== 6 && activeTab !== 7 && (
+          {activeTab !== 5 && activeTab !== 6 && activeTab !== 7 && (
             <Box sx={{ pt: 2, maxWidth: 500, flexShrink: 0 }}>
               <Divider sx={{ mb: 2 }} />
               <Button

--- a/app/client/src/views/Watch.js
+++ b/app/client/src/views/Watch.js
@@ -1,12 +1,12 @@
 import React, { useRef } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
-import { IconButton, Tooltip, Typography, Box, Divider } from '@mui/material'
+import { Divider, IconButton, Tooltip, Typography, Box } from '@mui/material'
 import { Helmet } from 'react-helmet'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import SnackbarAlert from '../components/alert/SnackbarAlert'
 import NotFound from './NotFound'
-import { VideoService } from '../services'
+import { VideoService, GameService } from '../services'
 import { getServedBy, getUrl, getPublicWatchUrl, copyToClipboard, getVideoSources } from '../common/utils'
 import VideoJSPlayer from '../components/misc/VideoJSPlayer'
 
@@ -48,6 +48,8 @@ const Watch = ({ authenticated }) => {
   const [notFound, setNotFound] = React.useState(false)
   const [views, setViews] = React.useState()
   const [viewAdded, setViewAdded] = React.useState(false)
+  const [selectedGame, setSelectedGame] = React.useState(null)
+  const [gamePillColor, setGamePillColor] = React.useState(null)
 
   const videoPlayerRef = useRef(null)
   const [alert, setAlert] = React.useState({ open: false })
@@ -62,6 +64,12 @@ const Watch = ({ authenticated }) => {
         if (!resp.info?.duration || resp.info?.duration < 10) {
           setViewAdded(true)
           VideoService.addView(id).catch((err) => console.error(err))
+        }
+        try {
+          const gameData = (await GameService.getVideoGame(id)).data
+          setSelectedGame(gameData || null)
+        } catch {
+          setSelectedGame(null)
         }
       } catch (err) {
         if (err.response && err.response.status === 404) {
@@ -79,6 +87,57 @@ const Watch = ({ authenticated }) => {
     }
     if (details == null) fetch()
   }, [details, id])
+
+  React.useEffect(() => {
+    if (!selectedGame?.icon_url) {
+      setGamePillColor(null)
+      return
+    }
+
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+
+    img.onload = () => {
+      const SIZE = 64
+      const canvas = document.createElement('canvas')
+      canvas.width = SIZE
+      canvas.height = SIZE
+      const ctx = canvas.getContext('2d')
+      ctx.drawImage(img, 0, 0, SIZE, SIZE)
+
+      const { data } = ctx.getImageData(0, 0, SIZE, SIZE)
+      let bestColor = null
+      let bestSaturation = -1
+
+      for (let i = 0; i < data.length; i += 4) {
+        const alpha = data[i + 3]
+        if (alpha < 128) continue
+
+        const r = data[i] / 255
+        const g = data[i + 1] / 255
+        const b = data[i + 2] / 255
+
+        const max = Math.max(r, g, b)
+        const min = Math.min(r, g, b)
+        const lightness = (max + min) / 2
+
+        if (lightness < 0.15 || lightness > 0.92) continue
+
+        const chroma = max - min
+        const saturation = chroma === 0 ? 0 : chroma / (1 - Math.abs(2 * lightness - 1))
+
+        if (saturation > bestSaturation) {
+          bestSaturation = saturation
+          bestColor = [data[i], data[i + 1], data[i + 2]]
+        }
+      }
+
+      setGamePillColor(bestSaturation > 0.2 ? bestColor : null)
+    }
+
+    img.onerror = () => setGamePillColor(null)
+    img.src = selectedGame.icon_url
+  }, [selectedGame?.icon_url])
 
   const getCurrentTime = () => {
     if (videoPlayerRef.current && typeof videoPlayerRef.current.currentTime === 'function') {
@@ -182,26 +241,81 @@ const Watch = ({ authenticated }) => {
             gap: 1.5,
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-            <Typography
-              sx={{
-                fontWeight: 900,
-                fontSize: { xs: 16, sm: 21 },
-                color: 'white',
-                lineHeight: 1.3,
-                letterSpacing: '-0.03em',
-                flex: 1,
-                minWidth: 0,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {details?.info?.title || 'Untitled'}
-            </Typography>
-            <Typography sx={{ fontSize: 14, color: '#FFFFFF55', flexShrink: 0 }}>
-              {views != null ? `${views.toLocaleString()} ${views === 1 ? 'view' : 'views'}` : ''}
-            </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap' }}>
+            {/* Left: title + views/date */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flex: 1, minWidth: 200 }}>
+              <Typography
+                sx={{
+                  fontWeight: 900,
+                  fontSize: { xs: 16, sm: 21 },
+                  color: 'white',
+                  lineHeight: 1.3,
+                  letterSpacing: '-0.03em',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {details?.info?.title || 'Untitled'}
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                {views != null && (
+                  <Typography sx={{ fontSize: 14, color: '#FFFFFF55' }}>
+                    {views.toLocaleString()} {views === 1 ? 'view' : 'views'}
+                  </Typography>
+                )}
+                {details?.recorded_at && (
+                  <>
+                    <Typography sx={{ fontSize: 14, color: '#FFFFFF55' }}>|</Typography>
+                    <Typography sx={{ fontSize: 14, color: '#FFFFFF55' }}>
+                      {new Date(details.recorded_at).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </Typography>
+                  </>
+                )}
+              </Box>
+            </Box>
+
+            {/* Right: game pill */}
+            {selectedGame && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 1, flexShrink: 0 }}>
+                <Box
+                  component={selectedGame.steamgriddb_id ? 'a' : 'div'}
+                  href={selectedGame.steamgriddb_id ? `#/games/${selectedGame.steamgriddb_id}` : undefined}
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 0.75,
+                    bgcolor: gamePillColor ? `rgba(${gamePillColor.join(',')}, 0.15)` : '#FFFFFF14',
+                    border: `1px solid ${gamePillColor ? `rgba(${gamePillColor.join(',')}, 0.5)` : '#FFFFFF26'}`,
+                    borderRadius: '8px',
+                    px: 1,
+                    py: 0.35,
+                    textDecoration: 'none',
+                    ...(selectedGame.steamgriddb_id && {
+                      cursor: 'pointer',
+                      '&:hover': {
+                        bgcolor: gamePillColor ? `rgba(${gamePillColor.join(',')}, 0.4)` : '#FFFFFF22',
+                      },
+                    }),
+                  }}
+                >
+                  {selectedGame.icon_url && (
+                    <img
+                      src={selectedGame.icon_url}
+                      alt=""
+                      style={{ width: 20, height: 20, objectFit: 'contain', borderRadius: 3, flexShrink: 0 }}
+                    />
+                  )}
+                  <Typography sx={{ fontSize: 12, color: 'white', whiteSpace: 'nowrap' }}>
+                    {selectedGame.name}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
           </Box>
 
           {details?.info?.description && (
@@ -212,8 +326,8 @@ const Watch = ({ authenticated }) => {
 
           <Divider sx={{ borderColor: '#FFFFFF14' }} />
 
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
-            <Box sx={{ ...rowBoxSx, flex: 1, minWidth: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box sx={{ ...rowBoxSx, flex: 1 }}>
               <Typography
                 sx={{
                   flex: 1,
@@ -240,8 +354,6 @@ const Watch = ({ authenticated }) => {
                 </IconButton>
               </Tooltip>
             </Box>
-
-            {/* Timestamp button */}
             <Tooltip title="Copy timestamp">
               <IconButton size="small" onClick={copyTimestamp} sx={actionBtnSx}>
                 <AccessTimeIcon sx={{ fontSize: 20 }} />


### PR DESCRIPTION
`Watch.js`
• Added game button to link to the game's public page
• Added date and views
<img width="3547" height="2155" alt="Screenshot 2026-03-13 at 11-14-54 This is the best claymore kill ever" src="https://github.com/user-attachments/assets/899345cf-79bf-4c2c-8103-cb2a3a9ea004" />


`Games.js`
• Removed the previously used parallax effect as it was really resource intensive and not worth the power for a simple animation. Replaced it with a simpler CSS `scale(1.04) `on hover instead.
• I also transferred over the same shimmer/slide up animations from `CompactGameCard.js `to the buttons for consistency.

`Settings.js`
• Folder Rules list max-height was increased to 800px
• Folder Rules styling has been updated to match the rest of the sites redesign
• RSS Feed settings have been moved to Integration tabs, removing the FEED tab from settings
• Added visibility toggle to the folder filter dropdown in Sidebar settings
• `handleSave` now calls `setSetting('ui_config', ...)` so sidebar changes apply without having to refresh every time

Additionally, the folder dropdown has been re-themed to match the rest of the design of the site
<img width="283" height="451" alt="Screenshot 2026-03-13 at 10 36 24 AM" src="https://github.com/user-attachments/assets/d1cc33fe-fb22-44a3-a21c-e3b0ffc4cb27" />
