### PR TITLE
Add better handling of missing SteamGridDB Assets

### DIFF
--- a/app/client/src/components/admin/CompactVideoCard.js
+++ b/app/client/src/components/admin/CompactVideoCard.js
@@ -576,6 +576,7 @@ const CompactBetaVideoCard = ({
               <img
                 src={game.icon_url}
                 alt={game.name}
+                onError={(e) => { e.currentTarget.parentElement.style.display = 'none' }}
                 style={{ width: 40, height: 40, objectFit: 'contain', display: 'block' }}
               />
             </a>

--- a/app/client/src/components/game/GameSearch.js
+++ b/app/client/src/components/game/GameSearch.js
@@ -6,7 +6,7 @@ import { GameService } from '../../services'
  * Reusable game search autocomplete component
  * Searches SteamGridDB, creates game if needed, and calls onGameLinked callback
  */
-const GameSearch = ({ onGameLinked, onError, disabled = false, placeholder = 'Search for a game...', sx = {} }) => {
+const GameSearch = ({ onGameLinked, onError, onWarning, disabled = false, placeholder = 'Search for a game...', sx = {} }) => {
   const [selectedGame, setSelectedGame] = React.useState(null)
   const [gameOptions, setGameOptions] = React.useState([])
   const [gameSearchLoading, setGameSearchLoading] = React.useState(false)
@@ -40,6 +40,7 @@ const GameSearch = ({ onGameLinked, onError, disabled = false, placeholder = 'Se
       // Check if game already exists
       const allGames = (await GameService.getGames()).data
       let game = allGames.find((g) => g.steamgriddb_id === newValue.id)
+      let pendingWarning = null
 
       if (!game) {
         // Create the game
@@ -54,12 +55,27 @@ const GameSearch = ({ onGameLinked, onError, disabled = false, placeholder = 'Se
           logo_url: assets.logo_url,
           icon_url: assets.icon_url,
         }
-        game = (await GameService.createGame(gameData)).data
+        const created = (await GameService.createGame(gameData)).data
+        if (created.missing_assets?.length) {
+          const labels = { heroes: 'hero art', logos: 'logo', icons: 'icon' }
+          const missing = created.missing_assets.map((k) => labels[k] || k)
+          const missingStr =
+            missing.length > 1
+              ? missing.slice(0, -1).join(', ') + ' and ' + missing[missing.length - 1]
+              : missing[0]
+          const verb = missing.length > 1 ? 'were' : 'was'
+          pendingWarning = `No ${missingStr} ${verb} available on SteamGridDB.`
+        }
+        game = created
       }
 
-      // Call the callback with the game
+      // Call the callback with the game, passing any warning as a second argument
+      // so callers that fire their own success alert can merge the two messages
       if (onGameLinked) {
-        onGameLinked(game)
+        onGameLinked(game, pendingWarning)
+      }
+      if (pendingWarning && onWarning) {
+        onWarning(pendingWarning)
       }
 
       // Reset the autocomplete

--- a/app/client/src/components/modal/UpdateDetailsModal.js
+++ b/app/client/src/components/modal/UpdateDetailsModal.js
@@ -138,7 +138,7 @@ const LinkedGameField = ({ game, onLink, onUnlink, alertHandler }) => {
     return (
       <Box sx={rowBoxSx}>
         {game.icon_url && (
-          <img src={game.icon_url} alt="" style={{ width: 28, height: 28, borderRadius: 4, objectFit: 'contain' }} />
+          <img src={game.icon_url} alt="" onError={(e) => { e.currentTarget.style.display = 'none' }} style={{ width: 28, height: 28, borderRadius: 4, objectFit: 'contain' }} />
         )}
         <Typography sx={{ color: 'white', fontSize: 14, flex: 1 }}>{game.name}</Typography>
         <IconButton size="small" onClick={onUnlink} sx={{ color: '#FFFFFF66', '&:hover': { color: 'white' }, p: 0.5 }}>
@@ -160,6 +160,7 @@ const LinkedGameField = ({ game, onLink, onUnlink, alertHandler }) => {
       <GameSearch
         onGameLinked={onLink}
         onError={() => alertHandler?.({ open: true, type: 'error', message: 'Failed to find game.' })}
+        onWarning={(msg) => alertHandler?.({ open: true, type: 'warning', message: msg })}
         placeholder="Search for a game..."
         sx={{ flex: 1 }}
       />

--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -270,11 +270,15 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
     }
   }, [videoId])
 
-  const handleGameLinked = async (game) => {
+  const handleGameLinked = async (game, warning) => {
     try {
       await GameService.linkVideoToGame(vid.video_id, game.id)
       setSelectedGame(game)
-      setAlert({ type: 'success', message: `Linked to ${game.name}`, open: true })
+      if (warning) {
+        setAlert({ type: 'warning', message: `Linked to ${game.name}. ${warning}`, open: true })
+      } else {
+        setAlert({ type: 'success', message: `Linked to ${game.name}`, open: true })
+      }
     } catch (err) {
       setAlert({ type: 'error', message: 'Failed to link game', open: true })
     }
@@ -612,6 +616,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                               <img
                                 src={selectedGame.icon_url}
                                 alt=""
+                                onError={(e) => { e.currentTarget.style.display = 'none' }}
                                 style={{ width: 20, height: 20, objectFit: 'contain', borderRadius: 3, flexShrink: 0 }}
                               />
                             )}
@@ -652,6 +657,7 @@ const VideoModal = ({ open, onClose, videoId, feedView, authenticated, updateCal
                             <img
                               src={selectedGame.icon_url}
                               alt=""
+                              onError={(e) => { e.currentTarget.style.display = 'none' }}
                               style={{ width: 20, height: 20, objectFit: 'contain', borderRadius: 3, flexShrink: 0 }}
                             />
                           )}

--- a/app/client/src/views/Dashboard.js
+++ b/app/client/src/views/Dashboard.js
@@ -469,6 +469,7 @@ const Dashboard = ({
                     message: err.response?.data || 'Error adding game',
                   })
                 }
+                onWarning={(msg) => setAlert({ open: true, type: 'warning', message: msg })}
                 placeholder="Search SteamGridDB..."
               />
             </>

--- a/app/client/src/views/Games.js
+++ b/app/client/src/views/Games.js
@@ -256,6 +256,7 @@ const Games = ({ authenticated, searchText }) => {
                     <Box
                       component="img"
                       src={game.hero_url}
+                      onError={(e) => { e.currentTarget.style.display = 'none' }}
                       sx={{
                         width: '100%',
                         height: '100%',
@@ -271,6 +272,7 @@ const Games = ({ authenticated, searchText }) => {
                     <Box
                       component="img"
                       src={game.logo_url}
+                      onError={(e) => { e.currentTarget.style.display = 'none' }}
                       sx={{
                         position: 'absolute',
                         top: '50%',

--- a/app/client/src/views/Settings.js
+++ b/app/client/src/views/Settings.js
@@ -800,6 +800,7 @@ const Settings = () => {
                                       onError={() =>
                                         setAlert({ open: true, type: 'error', message: 'Failed to search games' })
                                       }
+                                      onWarning={(msg) => setAlert({ open: true, type: 'warning', message: msg })}
                                     />
                                   </Box>
                                   <IconButton

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -1769,7 +1769,12 @@ def create_game():
 
     current_app.logger.info(f"Created game {data['name']} with assets: {result['assets']}")
 
-    return jsonify(game.json()), 201
+    response_data = game.json()
+    missing = [k for k, v in result['assets'].items() if v == 0]
+    if missing:
+        response_data['missing_assets'] = missing
+
+    return jsonify(response_data), 201
 
 @api.route('/api/videos/<video_id>/game', methods=["POST"])
 @login_required_unless_public_game_tag

--- a/app/server/fireshare/steamgrid.py
+++ b/app/server/fireshare/steamgrid.py
@@ -262,15 +262,7 @@ class SteamGridDBClient:
             logos = self.get_logos(game_id, limit=1)
             icons = self.get_icons(game_id, limit=1)
 
-            # Require at least 1 hero
-            if not heroes:
-                return {
-                    "success": False,
-                    "error": "No hero images available for this game",
-                    "assets": {"heroes": 0, "logos": 0, "icons": 0}
-                }
-
-            # Download heroes
+            # Download heroes (optional)
             hero_count = 0
             for i, hero in enumerate(heroes[:2], 1):
                 url = hero.get("url")
@@ -279,8 +271,7 @@ class SteamGridDBClient:
                     temp_path = temp_dir / f"hero_{i}{ext}"
                     if self._download_asset(url, temp_path):
                         hero_count += 1
-                    else:
-                        raise Exception(f"Failed to download hero_{i}")
+                    # Don't fail if hero download fails, it's optional
 
             # Download logo (optional)
             logo_count = 0


### PR DESCRIPTION
Based off of report #481 

Previously, if you tried to link a clip to a game that had a missing asset from steamgridDB, the api would refuse to add the game to the database. This sucks because if a game has a logo, an icon, but no hero image, the entire link would fail. If ANYTHING was missing, the link would fail.

Now, If there are missing assets for the game, the  game will still added anyway, and any available assets will still be downloaded. The user will be notified that the game currently has missing assets:
<img width="823" height="203" alt="Screenshot 2026-03-13 at 11 42 02 AM" src="https://github.com/user-attachments/assets/792c9bb8-22a8-45a0-913d-00b42103a243" />

<img width="487" alt="Screenshot 2026-03-13 at 11 55 19 AM" src="https://github.com/user-attachments/assets/9659984c-a19e-4963-a5cd-0a873cba288b" />
<img width="665" alt="Screenshot 2026-03-13 at 12 21 20 PM" src="https://github.com/user-attachments/assets/e9fdea49-c1a1-46f0-b3cd-8bc44575d677" />

The multiple files being touched are just because I needed to hookup `onError/onWarning `to all the places that` GameSearch.js` is used.

Because of the way fireshare currently pulls missing artwork, the next time that game's art is requested, it automatically attempts to re-fetch it from SteamGridDB. So if someone uploads hero art to SteamGridDB after the fact, your library will autodownload it as soon as it's available. 