### PR TITLE
Add manual SteamGridDB asset selection for games

### DIFF
--- a/app/client/src/components/cards/CompactVideoCard.js
+++ b/app/client/src/components/cards/CompactVideoCard.js
@@ -144,6 +144,19 @@ const CompactVideoCard = ({
       })
   }, [video.video_id])
 
+  const gameRef = React.useRef(game)
+  React.useEffect(() => { gameRef.current = game }, [game])
+  React.useEffect(() => {
+    const handler = (e) => {
+      const { steamgriddbId, bust } = e.detail
+      if (gameRef.current?.steamgriddb_id === steamgriddbId) {
+        setGame((prev) => prev ? { ...prev, icon_url: `/api/game/assets/${steamgriddbId}/icon_1.png?v=${bust}` } : prev)
+      }
+    }
+    window.addEventListener('gameAssetsUpdated', handler)
+    return () => window.removeEventListener('gameAssetsUpdated', handler)
+  }, [video.video_id])
+
   React.useEffect(() => {
     VideoService.getGameSuggestion(video.video_id)
       .then((response) => {

--- a/app/client/src/components/game/GameVideosHeader.js
+++ b/app/client/src/components/game/GameVideosHeader.js
@@ -1,7 +1,13 @@
 import React from 'react'
-import { Box } from '@mui/material'
+import { Box, IconButton } from '@mui/material'
+import ImageIcon from '@mui/icons-material/Image'
 
-const GameVideosHeader = ({ game, height = 200 }) => (
+const GameVideosHeader = ({ game, height = 200, cacheBust, editMode, onEditAssets }) => {
+  const bgUrl = game?.steamgriddb_id
+    ? `/api/game/assets/${game.steamgriddb_id}/hero_2.png?fallback=hero_1${cacheBust ? `&v=${cacheBust}` : ''}`
+    : null
+
+  return (
     <Box
       sx={{
         position: 'relative',
@@ -11,12 +17,12 @@ const GameVideosHeader = ({ game, height = 200 }) => (
         mb: 3,
       }}
     >
-    {game?.steamgriddb_id && (
+    {bgUrl && (
       <Box
         sx={{
           position: 'absolute',
           inset: 0,
-          backgroundImage: `url(/api/game/assets/${game.steamgriddb_id}/hero_2.png?fallback=hero_1)`,
+          backgroundImage: `url(${bgUrl})`,
           backgroundSize: 'cover',
           backgroundPosition: 'center',
           backgroundRepeat: 'no-repeat',
@@ -46,8 +52,25 @@ const GameVideosHeader = ({ game, height = 200 }) => (
           }}
         />
       )}
+      {editMode && game && (
+        <IconButton
+          size="small"
+          onClick={onEditAssets}
+          sx={{
+            position: 'absolute',
+            bottom: 8,
+            right: 8,
+            bgcolor: 'rgba(0, 0, 0, 0.6)',
+            color: 'white',
+            '&:hover': { bgcolor: 'rgba(0,0,0,0.85)' },
+          }}
+        >
+          <ImageIcon />
+        </IconButton>
+      )}
     </Box>
   </Box>
-)
+  )
+}
 
 export default GameVideosHeader

--- a/app/client/src/components/game/GameVideosHeader.js
+++ b/app/client/src/components/game/GameVideosHeader.js
@@ -2,10 +2,8 @@ import React from 'react'
 import { Box } from '@mui/material'
 import ImageIcon from '@mui/icons-material/Image'
 
-const GameVideosHeader = ({ game, height = 200, cacheBust, editMode, onEditAssets }) => {
-  const bgUrl = game?.steamgriddb_id
-    ? `/api/game/assets/${game.steamgriddb_id}/hero_2.png?fallback=hero_1${cacheBust ? `&v=${cacheBust}` : ''}`
-    : null
+const GameVideosHeader = ({ game, height = 200, editMode, onEditAssets }) => {
+  const bgUrl = game?.banner_url || game?.hero_url || null
 
   return (
     <Box

--- a/app/client/src/components/game/GameVideosHeader.js
+++ b/app/client/src/components/game/GameVideosHeader.js
@@ -1,9 +1,14 @@
 import React from 'react'
-import { Box } from '@mui/material'
+import { Box, Skeleton } from '@mui/material'
 import ImageIcon from '@mui/icons-material/Image'
 
 const GameVideosHeader = ({ game, height = 200, editMode, onEditAssets }) => {
   const bgUrl = game?.banner_url || game?.hero_url || null
+  const [imgLoaded, setImgLoaded] = React.useState(false)
+
+  React.useEffect(() => {
+    setImgLoaded(false)
+  }, [bgUrl])
 
   return (
     <Box
@@ -15,63 +20,81 @@ const GameVideosHeader = ({ game, height = 200, editMode, onEditAssets }) => {
         mb: 3,
       }}
     >
-    {bgUrl && (
-      <Box
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          backgroundImage: `url(${bgUrl})`,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          backgroundRepeat: 'no-repeat',
-          opacity: 0.7,
-          pointerEvents: 'none',
-        }}
-      />
-    )}
-    <Box
-      sx={{
-        position: 'relative',
-        height: '100%',
-        display: 'flex',
-        justifyContent: { xs: 'center', sm: 'flex-start' },
-        alignItems: 'center',
-        px: 3,
-      }}
-    >
-      {game?.logo_url && (
-        <Box
-          component="img"
-          src={game.logo_url}
-          sx={{
-            maxHeight: 80,
-            maxWidth: 300,
-            objectFit: 'contain',
-          }}
-        />
+      {bgUrl && (
+        <>
+          <Skeleton
+            variant="rectangular"
+            animation="wave"
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              opacity: imgLoaded ? 0 : 1,
+              transition: 'opacity 0.3s ease',
+            }}
+          />
+          <Box
+            component="img"
+            src={bgUrl}
+            onLoad={() => setImgLoaded(true)}
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              objectPosition: 'center',
+              opacity: imgLoaded ? 0.7 : 0,
+              transition: 'opacity 0.3s ease',
+              pointerEvents: 'none',
+            }}
+          />
+        </>
       )}
-    </Box>
-    {editMode && game && (
       <Box
-        onClick={onEditAssets}
         sx={{
-          position: 'absolute',
-          inset: 0,
-          bgcolor: '#00000080',
+          position: 'relative',
+          height: '100%',
           display: 'flex',
-          flexDirection: 'column',
+          justifyContent: { xs: 'center', sm: 'flex-start' },
           alignItems: 'center',
-          justifyContent: 'center',
-          gap: 1,
-          cursor: 'pointer',
-          transition: 'background-color 0.2s',
-          '&:hover': { bgcolor: '#000000A6' },
+          px: 3,
         }}
       >
-        <ImageIcon sx={{ color: 'white', fontSize: 52, pointerEvents: 'none' }} />
+        {game?.logo_url && (
+          <Box
+            component="img"
+            src={game.logo_url}
+            sx={{
+              maxHeight: 80,
+              maxWidth: 300,
+              objectFit: 'contain',
+            }}
+          />
+        )}
       </Box>
-    )}
-  </Box>
+      {editMode && game && (
+        <Box
+          onClick={onEditAssets}
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            bgcolor: '#00000080',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 1,
+            cursor: 'pointer',
+            transition: 'background-color 0.2s',
+            '&:hover': { bgcolor: '#000000A6' },
+          }}
+        >
+          <ImageIcon sx={{ color: 'white', fontSize: 52, pointerEvents: 'none' }} />
+        </Box>
+      )}
+    </Box>
   )
 }
 

--- a/app/client/src/components/game/GameVideosHeader.js
+++ b/app/client/src/components/game/GameVideosHeader.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, IconButton } from '@mui/material'
+import { Box } from '@mui/material'
 import ImageIcon from '@mui/icons-material/Image'
 
 const GameVideosHeader = ({ game, height = 200, cacheBust, editMode, onEditAssets }) => {
@@ -52,23 +52,27 @@ const GameVideosHeader = ({ game, height = 200, cacheBust, editMode, onEditAsset
           }}
         />
       )}
-      {editMode && game && (
-        <IconButton
-          size="small"
-          onClick={onEditAssets}
-          sx={{
-            position: 'absolute',
-            bottom: 8,
-            right: 8,
-            bgcolor: 'rgba(0, 0, 0, 0.6)',
-            color: 'white',
-            '&:hover': { bgcolor: 'rgba(0,0,0,0.85)' },
-          }}
-        >
-          <ImageIcon />
-        </IconButton>
-      )}
     </Box>
+    {editMode && game && (
+      <Box
+        onClick={onEditAssets}
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          bgcolor: '#00000080',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 1,
+          cursor: 'pointer',
+          transition: 'background-color 0.2s',
+          '&:hover': { bgcolor: '#000000A6' },
+        }}
+      >
+        <ImageIcon sx={{ color: 'white', fontSize: 52, pointerEvents: 'none' }} />
+      </Box>
+    )}
   </Box>
   )
 }

--- a/app/client/src/components/modal/EditGameAssetsModal.js
+++ b/app/client/src/components/modal/EditGameAssetsModal.js
@@ -1,0 +1,276 @@
+import React from 'react'
+import { Box, Button, CircularProgress, Modal, Stack, Typography, IconButton } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import CheckIcon from '@mui/icons-material/Check'
+import { GameService } from '../../services'
+
+// ─── Style constants ──────────────────────────────────────────────────────────
+
+const modalSx = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 700,
+  maxWidth: '95vw',
+  maxHeight: '90vh',
+  bgcolor: '#041223',
+  border: '1px solid #FFFFFF1A',
+  borderRadius: '12px',
+  boxShadow: '0 16px 48px #00000099',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+}
+
+
+const TABS = [
+  { type: 'hero', label: 'Hero', aspectRatio: '16 / 5', gridCols: 'repeat(auto-fill, minmax(240px, 1fr))', fit: 'cover' },
+  { type: 'logo', label: 'Logo', aspectRatio: '3 / 2',  gridCols: 'repeat(auto-fill, minmax(160px, 1fr))', fit: 'contain' },
+  { type: 'icon', label: 'Icon', aspectRatio: '1 / 1',  gridCols: 'repeat(auto-fill, minmax(110px, 1fr))', fit: 'cover' },
+]
+
+// ─── Tab bar item ─────────────────────────────────────────────────────────────
+
+const TabItem = ({ tab, isActive, onClick }) => (
+  <Box
+    onClick={onClick}
+    sx={{
+      px: 2,
+      py: 1.5,
+      cursor: 'pointer',
+      fontSize: 12,
+      fontWeight: 600,
+      letterSpacing: '0.08em',
+      textTransform: 'uppercase',
+      color: isActive ? 'white' : '#FFFFFFB3',
+      borderBottom: '2px solid',
+      borderColor: isActive ? '#3399FF' : 'transparent',
+      transition: 'color 0.15s ease, border-color 0.15s ease',
+      '&:hover': { color: 'white' },
+      userSelect: 'none',
+    }}
+  >
+    {tab.label}
+  </Box>
+)
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+const EditGameAssetsModal = ({ game, open, onClose, onSaved }) => {
+  const [activeTabIndex, setActiveTabIndex] = React.useState(0)
+  const [options, setOptions] = React.useState(null)
+  const [loadingOptions, setLoadingOptions] = React.useState(false)
+  const [pendingSelections, setPendingSelections] = React.useState({})
+  const [saving, setSaving] = React.useState(false)
+
+  React.useEffect(() => {
+    if (open && game) {
+      setActiveTabIndex(0)
+      setPendingSelections({})
+      setOptions(null)
+      setLoadingOptions(true)
+      GameService.getGameAssetOptions(game.steamgriddb_id)
+        .then((res) => setOptions(res.data))
+        .catch((err) => {
+          console.error('Failed to fetch asset options:', err)
+          setOptions({ heroes: [], logos: [], icons: [] })
+        })
+        .finally(() => setLoadingOptions(false))
+    }
+  }, [open, game])
+
+  const handleSave = async () => {
+    if (Object.keys(pendingSelections).length === 0) {
+      onClose()
+      return
+    }
+    setSaving(true)
+    try {
+      await Promise.all(
+        Object.entries(pendingSelections).map(([assetType, url]) =>
+          GameService.updateGameAsset(game.steamgriddb_id, assetType, url),
+        ),
+      )
+      onSaved()
+    } catch (err) {
+      console.error('Failed to save asset changes:', err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const getOptionsForTab = (tabIndex) => {
+    if (!options) return []
+    const type = TABS[tabIndex].type
+    if (type === 'hero') return options.heroes || []
+    if (type === 'logo') return options.logos || []
+    return options.icons || []
+  }
+
+  const activeTab = TABS[activeTabIndex]
+  const currentOptions = getOptionsForTab(activeTabIndex)
+  const hasPendingChanges = Object.keys(pendingSelections).length > 0
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box sx={modalSx}>
+        {/* ── Header ── */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: 3,
+            py: 2.5,
+            borderBottom: '1px solid #FFFFFF14',
+            flexShrink: 0,
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 800, color: 'white' }}>
+            Edit {game?.name}
+          </Typography>
+          <IconButton
+            onClick={onClose}
+            size="small"
+            sx={{ color: '#FFFFFF66', '&:hover': { color: 'white', bgcolor: '#FFFFFF14' } }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+
+        {/* ── Tab bar ── */}
+        <Box
+          sx={{
+            display: 'flex',
+            borderBottom: '1px solid #FFFFFF14',
+            px: 1,
+            flexShrink: 0,
+          }}
+        >
+          {TABS.map((tab, i) => (
+            <TabItem
+              key={tab.type}
+              tab={tab}
+              isActive={activeTabIndex === i}
+              onClick={() => setActiveTabIndex(i)}
+            />
+          ))}
+        </Box>
+
+        {/* ── Content area ── */}
+        <Box sx={{ flex: 1, overflow: 'auto', p: 3 }}>
+          {loadingOptions ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 180 }}>
+                <CircularProgress size={32} sx={{ color: '#3399FF' }} />
+              </Box>
+            ) : currentOptions.length === 0 ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 180 }}>
+                <Typography sx={{ color: '#FFFFFF4D', fontSize: 14 }}>
+                  No options available from SteamGridDB
+                </Typography>
+              </Box>
+            ) : (
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: activeTab.gridCols,
+                  gap: 1.5,
+                }}
+              >
+                {currentOptions.map((item) => {
+                  const isSelected = pendingSelections[activeTab.type] === item.url
+                  return (
+                    <Box
+                      key={item.id}
+                      onClick={() =>
+                        setPendingSelections((prev) => ({ ...prev, [activeTab.type]: item.url }))
+                      }
+                      sx={{
+                        position: 'relative',
+                        aspectRatio: activeTab.aspectRatio,
+                        borderRadius: '8px',
+                        overflow: 'hidden',
+                        cursor: 'pointer',
+                        border: '2px solid',
+                        borderColor: isSelected ? '#3399FF' : '#FFFFFF1A',
+                        bgcolor: '#FFFFFF0D',
+                        transition: 'border-color 0.15s ease, transform 0.15s ease',
+                        '&:hover': {
+                          borderColor: isSelected ? '#3399FF' : '#FFFFFF44',
+                          transform: 'scale(1.03)',
+                        },
+                      }}
+                    >
+                      <Box
+                        component="img"
+                        src={item.thumb || item.url}
+                        alt=""
+                        sx={{
+                          width: '100%',
+                          height: '100%',
+                          objectFit: activeTab.fit,
+                        }}
+                      />
+                      {isSelected && (
+                        <Box
+                          sx={{
+                            position: 'absolute',
+                            top: 6,
+                            right: 6,
+                            bgcolor: '#3399FF',
+                            borderRadius: '50%',
+                            width: 22,
+                            height: 22,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <CheckIcon sx={{ fontSize: 14, color: 'white' }} />
+                        </Box>
+                      )}
+                    </Box>
+                  )
+                })}
+              </Box>
+            )}
+        </Box>
+
+        {/* ── Footer ── */}
+        <Box
+          sx={{
+            px: 3,
+            py: 2,
+            borderTop: '1px solid #FFFFFF14',
+            flexShrink: 0,
+          }}
+        >
+          <Stack direction="row" spacing={1.5}>
+            <Button
+              fullWidth
+              variant="outlined"
+              onClick={onClose}
+              disabled={saving}
+              sx={{ color: 'white', borderColor: '#FFFFFF44', '&:hover': { borderColor: 'white', bgcolor: '#FFFFFF12' } }}
+            >
+              Cancel
+            </Button>
+            <Button
+              fullWidth
+              variant="contained"
+              onClick={handleSave}
+              disabled={saving || !hasPendingChanges}
+              sx={{ bgcolor: '#3399FF', '&:hover': { bgcolor: '#1976D2' } }}
+            >
+              {saving ? <CircularProgress size={16} sx={{ mr: 1, color: 'white' }} /> : null}
+              {saving ? 'Saving…' : 'Save Changes'}
+            </Button>
+          </Stack>
+        </Box>
+      </Box>
+    </Modal>
+  )
+}
+
+export default EditGameAssetsModal

--- a/app/client/src/components/modal/EditGameAssetsModal.js
+++ b/app/client/src/components/modal/EditGameAssetsModal.js
@@ -25,11 +25,15 @@ const modalSx = {
 }
 
 
-const TABS = [
-  { type: 'hero', label: 'Hero', aspectRatio: '16 / 5', gridCols: 'repeat(auto-fill, minmax(240px, 1fr))', fit: 'cover' },
-  { type: 'logo', label: 'Logo', aspectRatio: '3 / 2',  gridCols: 'repeat(auto-fill, minmax(160px, 1fr))', fit: 'contain' },
-  { type: 'icon', label: 'Icon', aspectRatio: '1 / 1',  gridCols: 'repeat(auto-fill, minmax(110px, 1fr))', fit: 'cover' },
+const ALL_TABS = [
+  { type: 'banner', label: 'Banner',    aspectRatio: '16 / 5', gridCols: 'repeat(auto-fill, minmax(240px, 1fr))', fit: 'cover',   pool: 'heroes' },
+  { type: 'hero',   label: 'Thumbnail', aspectRatio: '16 / 5', gridCols: 'repeat(auto-fill, minmax(240px, 1fr))', fit: 'cover',   pool: 'heroes' },
+  { type: 'logo',   label: 'Logo',      aspectRatio: '3 / 2',  gridCols: 'repeat(auto-fill, minmax(160px, 1fr))', fit: 'contain', pool: 'logos'  },
+  { type: 'icon',   label: 'Icon',      aspectRatio: '1 / 1',  gridCols: 'repeat(auto-fill, minmax(110px, 1fr))', fit: 'cover',   pool: 'icons'  },
 ]
+
+const BANNER_TABS = ALL_TABS.filter((t) => t.type !== 'hero')    // Banner, Logo, Icon
+const CARD_TABS   = ALL_TABS.filter((t) => t.type !== 'banner')  // Thumbnail, Logo, Icon
 
 // ─── Tab bar item ─────────────────────────────────────────────────────────────
 
@@ -58,7 +62,8 @@ const TabItem = ({ tab, isActive, onClick }) => (
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-const EditGameAssetsModal = ({ game, open, onClose, onSaved }) => {
+const EditGameAssetsModal = ({ game, open, onClose, onSaved, bannerOnly = false }) => {
+  const TABS = bannerOnly ? BANNER_TABS : CARD_TABS
   const [activeTabIndex, setActiveTabIndex] = React.useState(0)
   const [options, setOptions] = React.useState(null)
   const [loadingOptions, setLoadingOptions] = React.useState(false)
@@ -103,10 +108,7 @@ const EditGameAssetsModal = ({ game, open, onClose, onSaved }) => {
 
   const getOptionsForTab = (tabIndex) => {
     if (!options) return []
-    const type = TABS[tabIndex].type
-    if (type === 'hero') return options.heroes || []
-    if (type === 'logo') return options.logos || []
-    return options.icons || []
+    return options[TABS[tabIndex].pool] || []
   }
 
   const activeTab = TABS[activeTabIndex]
@@ -247,9 +249,8 @@ const EditGameAssetsModal = ({ game, open, onClose, onSaved }) => {
             flexShrink: 0,
           }}
         >
-          <Stack direction="row" spacing={1.5}>
+          <Stack direction="row" spacing={1.5} justifyContent="flex-end">
             <Button
-              fullWidth
               variant="outlined"
               onClick={onClose}
               disabled={saving}
@@ -258,14 +259,13 @@ const EditGameAssetsModal = ({ game, open, onClose, onSaved }) => {
               Cancel
             </Button>
             <Button
-              fullWidth
               variant="contained"
               onClick={handleSave}
               disabled={saving || !hasPendingChanges}
               sx={{ bgcolor: '#3399FF', '&:hover': { bgcolor: '#1976D2' } }}
             >
               {saving ? <CircularProgress size={16} sx={{ mr: 1, color: 'white' }} /> : null}
-              {saving ? 'Saving…' : 'Save Changes'}
+              {saving ? 'Saving…' : 'Save'}
             </Button>
           </Stack>
         </Box>

--- a/app/client/src/components/modal/EditGameAssetsModal.js
+++ b/app/client/src/components/modal/EditGameAssetsModal.js
@@ -48,7 +48,7 @@ const TabItem = ({ tab, isActive, onClick }) => (
       fontWeight: 600,
       letterSpacing: '0.08em',
       textTransform: 'uppercase',
-      color: isActive ? 'white' : '#FFFFFFB3',
+      color: '#bdbdbdb3',
       borderBottom: '2px solid',
       borderColor: isActive ? '#3399FF' : 'transparent',
       transition: 'color 0.15s ease, border-color 0.15s ease',

--- a/app/client/src/components/modal/EditGameAssetsModal.js
+++ b/app/client/src/components/modal/EditGameAssetsModal.js
@@ -12,6 +12,7 @@ const modalSx = {
   left: '50%',
   transform: 'translate(-50%, -50%)',
   width: 700,
+  height: 560,
   maxWidth: '95vw',
   maxHeight: '90vh',
   bgcolor: '#041223',

--- a/app/client/src/services/GameService.js
+++ b/app/client/src/services/GameService.js
@@ -11,6 +11,12 @@ const service = {
   getGameAssets(gameId) {
     return Api().get(`/api/steamgrid/game/${gameId}/assets`)
   },
+  getGameAssetOptions(gameId) {
+    return Api().get(`/api/steamgrid/game/${gameId}/assets/options`)
+  },
+  updateGameAsset(gameId, assetType, url) {
+    return Api().put(`/api/games/${gameId}/assets`, { asset_type: assetType, url })
+  },
   getGames() {
     return Api().get('/api/games')
   },

--- a/app/client/src/services/GameService.js
+++ b/app/client/src/services/GameService.js
@@ -1,5 +1,27 @@
 import Api from './Api'
 
+// Module-level map: steamgriddb_id -> bust timestamp, persists across navigation
+const _assetBusts = {}
+
+export const recordAssetBust = (steamgriddbId) => {
+  _assetBusts[steamgriddbId] = Date.now()
+}
+
+export const applyAssetBusts = (games) => {
+  return games.map((g) => {
+    const bust = _assetBusts[g.steamgriddb_id]
+    if (!bust) return g
+    const base = `/api/game/assets/${g.steamgriddb_id}`
+    return {
+      ...g,
+      hero_url: `${base}/hero_1.png?v=${bust}`,
+      banner_url: `${base}/hero_2.png?v=${bust}`,
+      logo_url: `${base}/logo_1.png?v=${bust}`,
+      icon_url: `${base}/icon_1.png?v=${bust}`,
+    }
+  })
+}
+
 const service = {
   searchSteamGrid(query) {
     return Api().get('/api/steamgrid/search', {

--- a/app/client/src/views/GameVideos.js
+++ b/app/client/src/views/GameVideos.js
@@ -1,17 +1,41 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { Box } from '@mui/material'
+import {
+  Box,
+  IconButton,
+  Button,
+  ButtonGroup,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+  Autocomplete,
+  TextField,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material'
 import { useParams } from 'react-router-dom'
 import Select from 'react-select'
-import { GameService } from '../services'
+import EditIcon from '@mui/icons-material/Edit'
+import CheckIcon from '@mui/icons-material/Check'
+import DeleteIcon from '@mui/icons-material/Delete'
+import LinkIcon from '@mui/icons-material/Link'
+import { GameService, VideoService } from '../services'
 import VideoCards from '../components/cards/VideoCards'
 import GameVideosHeader from '../components/game/GameVideosHeader'
+import GameSearch from '../components/game/GameSearch'
 import LoadingSpinner from '../components/misc/LoadingSpinner'
+import EditGameAssetsModal from '../components/modal/EditGameAssetsModal'
+import SnackbarAlert from '../components/alert/SnackbarAlert'
 import { SORT_OPTIONS } from '../common/constants'
 import selectSortTheme from '../common/reactSelectSortTheme'
 
 const GameVideos = ({ cardSize, authenticated, searchText }) => {
   const { gameId } = useParams()
+  const theme = useTheme()
+  const isMdDown = useMediaQuery(theme.breakpoints.down('md'))
+
   const [videos, setVideos] = React.useState([])
   const [filteredVideos, setFilteredVideos] = React.useState([])
   const [search, setSearch] = React.useState(searchText)
@@ -19,8 +43,21 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
   const [loading, setLoading] = React.useState(true)
   const [sortOrder, setSortOrder] = React.useState(SORT_OPTIONS?.[0] || { value: 'newest', label: 'Newest' })
   const [toolbarTarget, setToolbarTarget] = React.useState(null)
+  const [alert, setAlert] = React.useState({ open: false })
 
-  // Filter videos when searchText changes
+  // Edit mode
+  const [editMode, setEditMode] = React.useState(false)
+  const [selectedVideos, setSelectedVideos] = React.useState(new Set())
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
+  const [linkGameDialogOpen, setLinkGameDialogOpen] = React.useState(false)
+  const [games, setGames] = React.useState([])
+  const [selectedGame, setSelectedGame] = React.useState(null)
+  const [showAddNewGame, setShowAddNewGame] = React.useState(false)
+
+  // Cover art editing
+  const [editingAssets, setEditingAssets] = React.useState(false)
+  const [cacheBust, setCacheBust] = React.useState(null)
+
   if (searchText !== search) {
     setSearch(searchText)
     setFilteredVideos(videos.filter((v) => v.info?.title?.search(new RegExp(searchText, 'i')) >= 0))
@@ -46,46 +83,271 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
     setToolbarTarget(document.getElementById('navbar-toolbar-extra'))
   }, [])
 
+  React.useEffect(() => {
+    const searchContainer = document.getElementById('navbar-search-container')
+    if (searchContainer) {
+      searchContainer.style.display = editMode && isMdDown ? 'none' : ''
+    }
+  }, [editMode, isMdDown])
+
+  // ── Edit mode handlers ────────────────────────────────────────────────────
+
+  const handleEditModeToggle = () => {
+    setEditMode(!editMode)
+    if (editMode) setSelectedVideos(new Set())
+  }
+
+  const allSelected = sortedVideos => sortedVideos.length > 0 && selectedVideos.size === sortedVideos.length
+
+  const handleSelectAllToggle = (sortedVideos) => {
+    if (allSelected(sortedVideos)) {
+      setSelectedVideos(new Set())
+    } else {
+      setSelectedVideos(new Set(sortedVideos.map((v) => v.video_id)))
+    }
+  }
+
+  const handleVideoSelect = (videoId) => {
+    const next = new Set(selectedVideos)
+    if (next.has(videoId)) next.delete(videoId)
+    else next.add(videoId)
+    setSelectedVideos(next)
+  }
+
+  const handleDeleteConfirm = async () => {
+    try {
+      await Promise.all(Array.from(selectedVideos).map((id) => VideoService.delete(id)))
+      setAlert({ open: true, type: 'success', message: `Deleted ${selectedVideos.size} video${selectedVideos.size > 1 ? 's' : ''}` })
+      const res = await GameService.getGameVideos(gameId)
+      const fetched = res.data || []
+      setVideos(fetched)
+      setFilteredVideos(fetched)
+      setSelectedVideos(new Set())
+      setDeleteDialogOpen(false)
+      setEditMode(false)
+    } catch (err) {
+      setAlert({ open: true, type: 'error', message: err.response?.data || 'Error deleting videos' })
+    }
+  }
+
+  const handleLinkGameClick = async () => {
+    try {
+      const res = await GameService.getGames()
+      setGames(res.data)
+      setLinkGameDialogOpen(true)
+      setShowAddNewGame(false)
+      setSelectedGame(null)
+    } catch (err) {
+      setAlert({ open: true, type: 'error', message: err.response?.data || 'Error fetching games' })
+    }
+  }
+
+  const handleLinkGameConfirm = async () => {
+    if (!selectedGame) return
+    try {
+      await Promise.all(Array.from(selectedVideos).map((id) => GameService.linkVideoToGame(id, selectedGame.id)))
+      setAlert({ open: true, type: 'success', message: `Linked ${selectedVideos.size} video${selectedVideos.size > 1 ? 's' : ''} to ${selectedGame.name}` })
+      setSelectedVideos(new Set())
+      setLinkGameDialogOpen(false)
+      setSelectedGame(null)
+      setEditMode(false)
+    } catch (err) {
+      setAlert({ open: true, type: 'error', message: err.response?.data || 'Error linking videos' })
+    }
+  }
+
+  const handleNewGameCreated = async (newGame) => {
+    try {
+      await Promise.all(Array.from(selectedVideos).map((id) => GameService.linkVideoToGame(id, newGame.id)))
+      setAlert({ open: true, type: 'success', message: `Linked ${selectedVideos.size} video${selectedVideos.size > 1 ? 's' : ''} to ${newGame.name}` })
+      setSelectedVideos(new Set())
+      setLinkGameDialogOpen(false)
+      setShowAddNewGame(false)
+      setEditMode(false)
+    } catch (err) {
+      setAlert({ open: true, type: 'error', message: err.response?.data || 'Error linking videos to new game' })
+    }
+  }
+
+  // ── Cover art handlers ────────────────────────────────────────────────────
+
+  const handleAssetSaved = () => {
+    const bust = Date.now()
+    setEditingAssets(false)
+    setGame((prev) =>
+      prev
+        ? {
+            ...prev,
+            hero_url: prev.hero_url ? prev.hero_url.split('?v=')[0] + `?v=${bust}` : prev.hero_url,
+            logo_url: prev.logo_url ? prev.logo_url.split('?v=')[0] + `?v=${bust}` : prev.logo_url,
+            icon_url: prev.icon_url ? prev.icon_url.split('?v=')[0] + `?v=${bust}` : prev.icon_url,
+          }
+        : prev,
+    )
+    setCacheBust(bust)
+  }
+
+  // ── Sorting ───────────────────────────────────────────────────────────────
+
   const sortedVideos = React.useMemo(() => {
     if (!filteredVideos || !Array.isArray(filteredVideos)) return []
     return [...filteredVideos].sort((a, b) => {
-      if (sortOrder.value === 'most_views') {
-        return (b.view_count || 0) - (a.view_count || 0)
-      } else if (sortOrder.value === 'least_views') {
-        return (a.view_count || 0) - (b.view_count || 0)
-      } else {
-        const dateA = a.recorded_at ? new Date(a.recorded_at) : new Date(0)
-        const dateB = b.recorded_at ? new Date(b.recorded_at) : new Date(0)
-        return sortOrder.value === 'newest' ? dateB - dateA : dateA - dateB
-      }
+      if (sortOrder.value === 'most_views') return (b.view_count || 0) - (a.view_count || 0)
+      if (sortOrder.value === 'least_views') return (a.view_count || 0) - (b.view_count || 0)
+      const dateA = a.recorded_at ? new Date(a.recorded_at) : new Date(0)
+      const dateB = b.recorded_at ? new Date(b.recorded_at) : new Date(0)
+      return sortOrder.value === 'newest' ? dateB - dateA : dateA - dateB
     })
   }, [filteredVideos, sortOrder])
 
   if (loading) return <LoadingSpinner />
 
+  const isAllSelected = sortedVideos.length > 0 && selectedVideos.size === sortedVideos.length
+
   return (
-    <Box>
+    <>
+      <SnackbarAlert severity={alert.type} open={alert.open} setOpen={(open) => setAlert({ ...alert, open })}>
+        {alert.message}
+      </SnackbarAlert>
+
       {toolbarTarget &&
         ReactDOM.createPortal(
-          <Box sx={{ minWidth: { xs: 120, sm: 150 } }}>
-            <Select
-              value={sortOrder}
-              options={SORT_OPTIONS}
-              onChange={setSortOrder}
-              styles={selectSortTheme}
-              menuPortalTarget={document.body}
-              menuPosition="fixed"
-              blurInputOnSelect
-              isSearchable={false}
-            />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {!(editMode && isMdDown) && (
+              <Box sx={{ minWidth: { xs: 120, sm: 150 } }}>
+                <Select
+                  value={sortOrder}
+                  options={SORT_OPTIONS}
+                  onChange={setSortOrder}
+                  styles={selectSortTheme}
+                  menuPortalTarget={document.body}
+                  menuPosition="fixed"
+                  blurInputOnSelect
+                  isSearchable={false}
+                />
+              </Box>
+            )}
+            {authenticated && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                {editMode && (
+                  <ButtonGroup variant="contained" sx={{ height: 38, minWidth: 'fit-content' }}>
+                    <Button color="primary" onClick={() => handleSelectAllToggle(sortedVideos)}>
+                      {isAllSelected ? 'Select None' : 'Select All'}
+                    </Button>
+                    <Button
+                      color="primary"
+                      startIcon={<LinkIcon />}
+                      onClick={handleLinkGameClick}
+                      disabled={selectedVideos.size === 0}
+                    >
+                      Link to Game {selectedVideos.size > 0 && !isMdDown && `(${selectedVideos.size})`}
+                    </Button>
+                    <Button
+                      color="error"
+                      startIcon={<DeleteIcon />}
+                      onClick={() => setDeleteDialogOpen(true)}
+                      disabled={selectedVideos.size === 0}
+                    >
+                      Delete {selectedVideos.size > 0 && !isMdDown && `(${selectedVideos.size})`}
+                    </Button>
+                  </ButtonGroup>
+                )}
+                <IconButton
+                  onClick={handleEditModeToggle}
+                  sx={{
+                    bgcolor: editMode ? 'primary.main' : '#001E3C',
+                    borderRadius: '8px',
+                    height: '38px',
+                    border: !editMode ? '1px solid #2684FF' : 'none',
+                    '&:hover': { bgcolor: editMode ? 'primary.dark' : 'rgba(255, 255, 255, 0.2)' },
+                  }}
+                >
+                  {editMode ? <CheckIcon /> : <EditIcon />}
+                </IconButton>
+              </Box>
+            )}
           </Box>,
           toolbarTarget,
         )}
-      <GameVideosHeader game={game} />
+
+      <GameVideosHeader
+        game={game}
+        cacheBust={cacheBust}
+        editMode={editMode}
+        onEditAssets={() => setEditingAssets(true)}
+      />
       <Box sx={{ p: 3 }}>
-        <VideoCards videos={sortedVideos} authenticated={authenticated} size={cardSize} feedView={false} />
+        <VideoCards
+          videos={sortedVideos}
+          authenticated={authenticated}
+          size={cardSize}
+          feedView={false}
+          editMode={editMode}
+          selectedVideos={selectedVideos}
+          onVideoSelect={handleVideoSelect}
+        />
       </Box>
-    </Box>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>
+        <DialogTitle>Delete {selectedVideos.size} Video{selectedVideos.size > 1 ? 's' : ''}?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete the selected video{selectedVideos.size > 1 ? 's' : ''}? This will
+            permanently delete the video file{selectedVideos.size > 1 ? 's' : ''}.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleDeleteConfirm} variant="contained" color="error">Delete</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Link to Game Dialog */}
+      <Dialog open={linkGameDialogOpen} onClose={() => { setLinkGameDialogOpen(false); setSelectedGame(null) }} maxWidth="sm" fullWidth>
+        <DialogTitle>Link {selectedVideos.size} Clip{selectedVideos.size !== 1 ? 's' : ''} to Game</DialogTitle>
+        <DialogContent sx={{ pt: 3 }}>
+          {!showAddNewGame ? (
+            <Autocomplete
+              options={[...games, { id: 'add-new', name: 'Add a new game...', isAddNew: true }]}
+              getOptionLabel={(option) => option.name || ''}
+              value={selectedGame}
+              onChange={(_, newValue) => {
+                if (newValue?.isAddNew) { setShowAddNewGame(true); setSelectedGame(null) }
+                else setSelectedGame(newValue)
+              }}
+              renderInput={(params) => <TextField {...params} placeholder="Select a game..." />}
+              renderOption={(props, option) => (
+                <Box component="li" {...props} sx={{ display: 'flex', alignItems: 'center', gap: 1, fontStyle: option.isAddNew ? 'italic' : 'normal', color: option.isAddNew ? 'primary.main' : 'inherit' }}>
+                  {option.icon_url && <img src={option.icon_url} alt={option.name} style={{ width: 32, height: 32, objectFit: 'contain' }} />}
+                  <Typography>{option.name}</Typography>
+                </Box>
+              )}
+            />
+          ) : (
+            <GameSearch
+              onGameLinked={handleNewGameCreated}
+              onError={(err) => setAlert({ open: true, type: 'error', message: err.response?.data || 'Error adding game' })}
+              onWarning={(msg) => setAlert({ open: true, type: 'warning', message: msg })}
+              placeholder="Search SteamGridDB..."
+            />
+          )}
+        </DialogContent>
+        <DialogActions>
+          {showAddNewGame && <Button onClick={() => setShowAddNewGame(false)} sx={{ mr: 'auto' }}>Back to List</Button>}
+          <Button onClick={() => { setLinkGameDialogOpen(false); setSelectedGame(null) }}>Cancel</Button>
+          {!showAddNewGame && <Button onClick={handleLinkGameConfirm} variant="contained" disabled={!selectedGame}>Link</Button>}
+        </DialogActions>
+      </Dialog>
+
+      {/* Cover Art Modal */}
+      <EditGameAssetsModal
+        game={game}
+        open={editingAssets}
+        onClose={() => setEditingAssets(false)}
+        onSaved={handleAssetSaved}
+      />
+    </>
   )
 }
 

--- a/app/client/src/views/GameVideos.js
+++ b/app/client/src/views/GameVideos.js
@@ -22,6 +22,7 @@ import CheckIcon from '@mui/icons-material/Check'
 import DeleteIcon from '@mui/icons-material/Delete'
 import LinkIcon from '@mui/icons-material/Link'
 import { GameService, VideoService } from '../services'
+import { recordAssetBust, applyAssetBusts } from '../services/GameService'
 import VideoCards from '../components/cards/VideoCards'
 import GameVideosHeader from '../components/game/GameVideosHeader'
 import GameSearch from '../components/game/GameSearch'
@@ -56,7 +57,6 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
 
   // Cover art editing
   const [editingAssets, setEditingAssets] = React.useState(false)
-  const [cacheBust, setCacheBust] = React.useState(null)
 
   if (searchText !== search) {
     setSearch(searchText)
@@ -66,7 +66,7 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
   React.useEffect(() => {
     Promise.all([GameService.getGames(), GameService.getGameVideos(gameId)])
       .then(([gamesRes, videosRes]) => {
-        const foundGame = gamesRes.data.find((g) => g.steamgriddb_id === parseInt(gameId))
+        const foundGame = applyAssetBusts(gamesRes.data).find((g) => g.steamgriddb_id === parseInt(gameId))
         setGame(foundGame)
         const fetchedVideos = videosRes.data || []
         setVideos(fetchedVideos)
@@ -173,6 +173,9 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
 
   const handleAssetSaved = () => {
     const bust = Date.now()
+    const parsedGameId = parseInt(gameId)
+    recordAssetBust(parsedGameId)
+    window.dispatchEvent(new CustomEvent('gameAssetsUpdated', { detail: { steamgriddbId: parsedGameId, bust } }))
     setEditingAssets(false)
     setGame((prev) => {
       if (!prev) return prev
@@ -180,11 +183,11 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
       return {
         ...prev,
         hero_url: `${base}/hero_1.png?v=${bust}`,
+        banner_url: `${base}/hero_2.png?v=${bust}`,
         logo_url: `${base}/logo_1.png?v=${bust}`,
         icon_url: `${base}/icon_1.png?v=${bust}`,
       }
     })
-    setCacheBust(bust)
   }
 
   // ── Sorting ───────────────────────────────────────────────────────────────
@@ -272,7 +275,6 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
 
       <GameVideosHeader
         game={game}
-        cacheBust={cacheBust}
         editMode={editMode}
         onEditAssets={() => setEditingAssets(true)}
       />
@@ -346,6 +348,7 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
         open={editingAssets}
         onClose={() => setEditingAssets(false)}
         onSaved={handleAssetSaved}
+        bannerOnly
       />
     </>
   )

--- a/app/client/src/views/GameVideos.js
+++ b/app/client/src/views/GameVideos.js
@@ -174,16 +174,16 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
   const handleAssetSaved = () => {
     const bust = Date.now()
     setEditingAssets(false)
-    setGame((prev) =>
-      prev
-        ? {
-            ...prev,
-            hero_url: prev.hero_url ? prev.hero_url.split('?v=')[0] + `?v=${bust}` : prev.hero_url,
-            logo_url: prev.logo_url ? prev.logo_url.split('?v=')[0] + `?v=${bust}` : prev.logo_url,
-            icon_url: prev.icon_url ? prev.icon_url.split('?v=')[0] + `?v=${bust}` : prev.icon_url,
-          }
-        : prev,
-    )
+    setGame((prev) => {
+      if (!prev) return prev
+      const base = `/api/game/assets/${prev.steamgriddb_id}`
+      return {
+        ...prev,
+        hero_url: `${base}/hero_1.png?v=${bust}`,
+        logo_url: `${base}/logo_1.png?v=${bust}`,
+        icon_url: `${base}/icon_1.png?v=${bust}`,
+      }
+    })
     setCacheBust(bust)
   }
 
@@ -259,7 +259,7 @@ const GameVideos = ({ cardSize, authenticated, searchText }) => {
                     borderRadius: '8px',
                     height: '38px',
                     border: !editMode ? '1px solid #2684FF' : 'none',
-                    '&:hover': { bgcolor: editMode ? 'primary.dark' : 'rgba(255, 255, 255, 0.2)' },
+                    '&:hover': { bgcolor: editMode ? 'primary.dark' : '#FFFFFF33' },
                   }}
                 >
                   {editMode ? <CheckIcon /> : <EditIcon />}

--- a/app/client/src/views/Games.js
+++ b/app/client/src/views/Games.js
@@ -23,6 +23,7 @@ import CheckIcon from '@mui/icons-material/Check'
 import ImageIcon from '@mui/icons-material/Image'
 import { useNavigate } from 'react-router-dom'
 import { GameService } from '../services'
+import { recordAssetBust, applyAssetBusts } from '../services/GameService'
 import LoadingSpinner from '../components/misc/LoadingSpinner'
 import EditGameAssetsModal from '../components/modal/EditGameAssetsModal'
 
@@ -48,7 +49,7 @@ const Games = ({ authenticated, searchText }) => {
   React.useEffect(() => {
     GameService.getGames()
       .then((res) => {
-        setGames(res.data)
+        setGames(applyAssetBusts(res.data))
         setLoading(false)
       })
       .catch((err) => {
@@ -138,6 +139,8 @@ const Games = ({ authenticated, searchText }) => {
   const handleAssetSaved = () => {
     const editedId = editingGame?.steamgriddb_id
     const bust = Date.now()
+    recordAssetBust(editedId)
+    window.dispatchEvent(new CustomEvent('gameAssetsUpdated', { detail: { steamgriddbId: editedId, bust } }))
     setEditingGame(null)
     setGames((prev) =>
       prev.map((g) => {
@@ -146,6 +149,7 @@ const Games = ({ authenticated, searchText }) => {
         return {
           ...g,
           hero_url: `${base}/hero_1.png?v=${bust}`,
+          banner_url: `${base}/hero_2.png?v=${bust}`,
           logo_url: `${base}/logo_1.png?v=${bust}`,
           icon_url: `${base}/icon_1.png?v=${bust}`,
         }

--- a/app/client/src/views/Games.js
+++ b/app/client/src/views/Games.js
@@ -14,6 +14,7 @@ import {
   DialogContent,
   DialogActions,
   FormControlLabel,
+  Skeleton,
   useTheme,
   useMediaQuery,
 } from '@mui/material'
@@ -36,6 +37,7 @@ const Games = ({ authenticated, searchText }) => {
   const [deleteAssociatedVideos, setDeleteAssociatedVideos] = React.useState(false)
   const [toolbarTarget, setToolbarTarget] = React.useState(null)
   const [editingGame, setEditingGame] = React.useState(null)
+  const [loadedHeroes, setLoadedHeroes] = React.useState(new Set())
   const navigate = useNavigate()
   const theme = useTheme()
   const isMdDown = useMediaQuery(theme.breakpoints.down('md'))
@@ -283,18 +285,35 @@ const Games = ({ authenticated, searchText }) => {
                   )}
 
                   {game.hero_url && (
-                    <Box
-                      component="img"
-                      src={game.hero_url}
-                      onError={(e) => { e.currentTarget.style.display = 'none' }}
-                      sx={{
-                        width: '100%',
-                        height: '100%',
-                        objectFit: 'cover',
-                        position: 'absolute',
-                        filter: 'brightness(0.7)',
-                      }}
-                    />
+                    <>
+                      <Skeleton
+                        variant="rectangular"
+                        animation="wave"
+                        sx={{
+                          position: 'absolute',
+                          inset: 0,
+                          width: '100%',
+                          height: '100%',
+                          opacity: loadedHeroes.has(game.id) ? 0 : 1,
+                          transition: 'opacity 0.3s ease',
+                        }}
+                      />
+                      <Box
+                        component="img"
+                        src={game.hero_url}
+                        onLoad={() => setLoadedHeroes((prev) => new Set([...prev, game.id]))}
+                        onError={(e) => { e.currentTarget.style.display = 'none' }}
+                        sx={{
+                          width: '100%',
+                          height: '100%',
+                          objectFit: 'cover',
+                          position: 'absolute',
+                          filter: 'brightness(0.7)',
+                          opacity: loadedHeroes.has(game.id) ? 1 : 0,
+                          transition: 'opacity 0.3s ease',
+                        }}
+                      />
+                    </>
                   )}
                   {game.logo_url && (
                     <Box

--- a/app/client/src/views/Games.js
+++ b/app/client/src/views/Games.js
@@ -20,9 +20,11 @@ import {
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
 import CheckIcon from '@mui/icons-material/Check'
+import ImageIcon from '@mui/icons-material/Image'
 import { useNavigate } from 'react-router-dom'
 import { GameService } from '../services'
 import LoadingSpinner from '../components/misc/LoadingSpinner'
+import EditGameAssetsModal from '../components/modal/EditGameAssetsModal'
 
 const Games = ({ authenticated, searchText }) => {
   const [games, setGames] = React.useState([])
@@ -32,6 +34,7 @@ const Games = ({ authenticated, searchText }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [deleteAssociatedVideos, setDeleteAssociatedVideos] = React.useState(false)
   const [toolbarTarget, setToolbarTarget] = React.useState(null)
+  const [editingGame, setEditingGame] = React.useState(null)
   const navigate = useNavigate()
   const theme = useTheme()
   const isMdDown = useMediaQuery(theme.breakpoints.down('md'))
@@ -130,6 +133,27 @@ const Games = ({ authenticated, searchText }) => {
     } else {
       navigate(`/games/${gameId}`)
     }
+  }
+
+  const handleAssetSaved = () => {
+    const editedId = editingGame?.steamgriddb_id
+    setEditingGame(null)
+    GameService.getGames()
+      .then((res) => {
+        const bust = `?v=${Date.now()}`
+        setGames(
+          res.data.map((g) => {
+            if (g.steamgriddb_id !== editedId) return g
+            return {
+              ...g,
+              hero_url: g.hero_url ? g.hero_url + bust : g.hero_url,
+              logo_url: g.logo_url ? g.logo_url + bust : g.logo_url,
+              icon_url: g.icon_url ? g.icon_url + bust : g.icon_url,
+            }
+          }),
+        )
+      })
+      .catch((err) => console.error('Error refreshing games:', err))
   }
 
   if (loading) return <LoadingSpinner />
@@ -235,6 +259,28 @@ const Games = ({ authenticated, searchText }) => {
                     />
                   )}
 
+                  {/* Edit assets button (edit mode only) */}
+                  {editMode && (
+                    <IconButton
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setEditingGame(game)
+                      }}
+                      sx={{
+                        position: 'absolute',
+                        top: 8,
+                        right: 8,
+                        zIndex: 2,
+                        bgcolor: 'rgba(0, 0, 0, 0.6)',
+                        color: 'white',
+                        '&:hover': { bgcolor: 'rgba(0,0,0,0.85)' },
+                      }}
+                    >
+                      <ImageIcon fontSize="small" />
+                    </IconButton>
+                  )}
+
                   {game.hero_url && (
                     <Box
                       component="img"
@@ -272,6 +318,14 @@ const Games = ({ authenticated, searchText }) => {
             )
           })}
       </Grid>
+
+      {/* Edit Game Assets Modal */}
+      <EditGameAssetsModal
+        game={editingGame}
+        open={!!editingGame}
+        onClose={() => setEditingGame(null)}
+        onSaved={handleAssetSaved}
+      />
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={deleteDialogOpen} onClose={handleDeleteCancel}>

--- a/app/client/src/views/Games.js
+++ b/app/client/src/views/Games.js
@@ -137,23 +137,20 @@ const Games = ({ authenticated, searchText }) => {
 
   const handleAssetSaved = () => {
     const editedId = editingGame?.steamgriddb_id
+    const bust = Date.now()
     setEditingGame(null)
-    GameService.getGames()
-      .then((res) => {
-        const bust = `?v=${Date.now()}`
-        setGames(
-          res.data.map((g) => {
-            if (g.steamgriddb_id !== editedId) return g
-            return {
-              ...g,
-              hero_url: g.hero_url ? g.hero_url + bust : g.hero_url,
-              logo_url: g.logo_url ? g.logo_url + bust : g.logo_url,
-              icon_url: g.icon_url ? g.icon_url + bust : g.icon_url,
-            }
-          }),
-        )
-      })
-      .catch((err) => console.error('Error refreshing games:', err))
+    setGames((prev) =>
+      prev.map((g) => {
+        if (g.steamgriddb_id !== editedId) return g
+        const base = `/api/game/assets/${g.steamgriddb_id}`
+        return {
+          ...g,
+          hero_url: `${base}/hero_1.png?v=${bust}`,
+          logo_url: `${base}/logo_1.png?v=${bust}`,
+          icon_url: `${base}/icon_1.png?v=${bust}`,
+        }
+      }),
+    )
   }
 
   if (loading) return <LoadingSpinner />
@@ -194,7 +191,7 @@ const Games = ({ authenticated, searchText }) => {
                     height: '38px',
                     border: !editMode ? '1px solid #2684FF' : 'none',
                     '&:hover': {
-                      bgcolor: editMode ? 'primary.dark' : 'rgba(255, 255, 255, 0.2)',
+                      bgcolor: editMode ? 'primary.dark' : '#FFFFFF33',
                     },
                   }}
                 >
@@ -232,7 +229,7 @@ const Games = ({ authenticated, searchText }) => {
                     borderColor: isSelected ? 'primary.main' : 'transparent',
                     '&:hover': {
                       transform: 'scale(1.04)',
-                      boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+                      boxShadow: '0 8px 24px #00000080',
                     },
                   }}
                 >
@@ -250,7 +247,7 @@ const Games = ({ authenticated, searchText }) => {
                         left: 8,
                         zIndex: 2,
                         color: 'white',
-                        bgcolor: 'rgba(0, 0, 0, 0.5)',
+                        bgcolor: '#00000080',
                         borderRadius: '4px',
                         '&.Mui-checked': {
                           color: 'primary.main',
@@ -272,9 +269,9 @@ const Games = ({ authenticated, searchText }) => {
                         top: 8,
                         right: 8,
                         zIndex: 2,
-                        bgcolor: 'rgba(0, 0, 0, 0.6)',
+                        bgcolor: '#00000099',
                         color: 'white',
-                        '&:hover': { bgcolor: 'rgba(0,0,0,0.85)' },
+                        '&:hover': { bgcolor: '#000000D9' },
                       }}
                     >
                       <ImageIcon fontSize="small" />

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -1709,7 +1709,8 @@ def update_game_asset(steamgriddb_id):
 
     client = SteamGridDBClient(api_key)
     ext = client._get_extension_from_url(url)
-    base_name = f'{asset_type}_1'
+    # Hero uses slot 2 (header displays hero_2 with fallback to hero_1)
+    base_name = 'hero_2' if asset_type == 'hero' else f'{asset_type}_1'
 
     paths = current_app.config['PATHS']
     asset_dir = paths['data'] / 'game_assets' / str(steamgriddb_id)

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -1672,6 +1672,74 @@ def get_steamgrid_assets(game_id):
     assets = client.get_game_assets(game_id)
     return jsonify(assets)
 
+@api.route('/api/steamgrid/game/<int:game_id>/assets/options', methods=["GET"])
+def get_steamgrid_asset_options(game_id):
+    api_key = get_steamgriddb_api_key()
+    if not api_key:
+        return Response(status=503, response='SteamGridDB API key not configured.')
+
+    client = SteamGridDBClient(api_key)
+    options = client.get_all_asset_options(game_id)
+    return jsonify(options)
+
+@api.route('/api/games/<int:steamgriddb_id>/assets', methods=["PUT"])
+@login_required
+def update_game_asset(steamgriddb_id):
+    import tempfile
+
+    data = request.get_json()
+    if not data:
+        return Response(status=400, response='Request body required.')
+
+    asset_type = data.get('asset_type')
+    url = data.get('url')
+
+    if asset_type not in ('hero', 'logo', 'icon'):
+        return Response(status=400, response='asset_type must be hero, logo, or icon.')
+    if not url:
+        return Response(status=400, response='url is required.')
+
+    game = GameMetadata.query.filter_by(steamgriddb_id=steamgriddb_id).first()
+    if not game:
+        return Response(status=404, response='Game not found.')
+
+    api_key = get_steamgriddb_api_key()
+    if not api_key:
+        return Response(status=503, response='SteamGridDB API key not configured.')
+
+    client = SteamGridDBClient(api_key)
+    ext = client._get_extension_from_url(url)
+    base_name = f'{asset_type}_1'
+
+    paths = current_app.config['PATHS']
+    asset_dir = paths['data'] / 'game_assets' / str(steamgriddb_id)
+    asset_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove existing files for this slot (any extension)
+    for existing in asset_dir.glob(f'{base_name}.*'):
+        try:
+            existing.unlink()
+        except OSError as e:
+            current_app.logger.warning(f'Could not remove old asset {existing}: {e}')
+
+    dest_path = asset_dir / f'{base_name}{ext}'
+
+    # Download to temp file first, then move to final location
+    temp_dir = Path(tempfile.mkdtemp())
+    try:
+        temp_path = temp_dir / f'{base_name}{ext}'
+        success = client._download_asset(url, temp_path)
+        if not success:
+            return Response(status=502, response='Failed to download asset from SteamGridDB.')
+        import shutil
+        shutil.move(str(temp_path), str(dest_path))
+    finally:
+        if temp_dir.exists():
+            import shutil
+            shutil.rmtree(temp_dir)
+
+    return Response(status=200)
+
 @api.route('/api/games', methods=["GET"])
 def get_games():
 

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -1694,8 +1694,8 @@ def update_game_asset(steamgriddb_id):
     asset_type = data.get('asset_type')
     url = data.get('url')
 
-    if asset_type not in ('hero', 'logo', 'icon'):
-        return Response(status=400, response='asset_type must be hero, logo, or icon.')
+    if asset_type not in ('hero', 'banner', 'logo', 'icon'):
+        return Response(status=400, response='asset_type must be hero, banner, logo, or icon.')
     if not url:
         return Response(status=400, response='url is required.')
 
@@ -1709,8 +1709,8 @@ def update_game_asset(steamgriddb_id):
 
     client = SteamGridDBClient(api_key)
     ext = client._get_extension_from_url(url)
-    # Hero uses slot 2 (header displays hero_2 with fallback to hero_1)
-    base_name = 'hero_2' if asset_type == 'hero' else f'{asset_type}_1'
+    slot_map = {'hero': 'hero_1', 'banner': 'hero_2', 'logo': 'logo_1', 'icon': 'icon_1'}
+    base_name = slot_map[asset_type]
 
     paths = current_app.config['PATHS']
     asset_dir = paths['data'] / 'game_assets' / str(steamgriddb_id)
@@ -1770,7 +1770,20 @@ def get_games():
             .all()
         )
 
-    return jsonify([game.json() for game in games])
+    paths = current_app.config['PATHS']
+    result = []
+    for game in games:
+        data = game.json()
+        if game.steamgriddb_id:
+            asset_dir = paths['data'] / 'game_assets' / str(game.steamgriddb_id)
+            for base, key in [('hero_1', 'hero_url'), ('hero_2', 'banner_url'), ('logo_1', 'logo_url'), ('icon_1', 'icon_url')]:
+                found = find_asset_with_extensions(asset_dir, base)
+                if found and data.get(key):
+                    data[key] = data[key] + f'?v={int(found.stat().st_mtime)}'
+        result.append(data)
+    resp = jsonify(result)
+    resp.headers['Cache-Control'] = 'no-store'
+    return resp
 
 @api.route('/api/games', methods=["POST"])
 @login_required_unless_public_game_tag
@@ -1882,7 +1895,17 @@ def get_video_game(video_id):
     link = VideoGameLink.query.filter_by(video_id=video_id).first()
     if not link:
         return jsonify(None)
-    return jsonify(link.game.json())
+    data = link.game.json()
+    if link.game.steamgriddb_id:
+        paths = current_app.config['PATHS']
+        asset_dir = paths['data'] / 'game_assets' / str(link.game.steamgriddb_id)
+        for base, key in [('hero_1', 'hero_url'), ('hero_2', 'banner_url'), ('logo_1', 'logo_url'), ('icon_1', 'icon_url')]:
+            found = find_asset_with_extensions(asset_dir, base)
+            if found and data.get(key):
+                data[key] = data[key] + f'?v={int(found.stat().st_mtime)}'
+    resp = jsonify(data)
+    resp.headers['Cache-Control'] = 'no-store'
+    return resp
 
 @api.route('/api/videos/<video_id>/game', methods=["DELETE"])
 @login_required_unless_public_game_tag
@@ -1980,7 +2003,11 @@ def get_game_asset(steamgriddb_id, filename):
     mime_type = mime_types.get(ext, 'image/png')
 
     response = send_file(asset_path, mimetype=mime_type)
-    return add_cache_headers(response, f"{steamgriddb_id}-{filename}")
+    stat = asset_path.stat()
+    etag = f"{steamgriddb_id}-{filename}-{int(stat.st_mtime)}-{stat.st_size}"
+    response.headers['Cache-Control'] = 'public, max-age=3600'
+    response.headers['ETag'] = f'"{etag}"'
+    return response
 
 @api.route('/api/games/<int:steamgriddb_id>/videos', methods=["GET"])
 def get_game_videos(steamgriddb_id):

--- a/app/server/fireshare/api.py
+++ b/app/server/fireshare/api.py
@@ -1699,6 +1699,19 @@ def update_game_asset(steamgriddb_id):
     if not url:
         return Response(status=400, response='url is required.')
 
+    from urllib.parse import urlparse
+    _ALLOWED_STEAMGRIDDB_HOSTS = {
+        'cdn2.steamgriddb.com',
+        'cdn.steamgriddb.com',
+        'steamgriddb.com',
+    }
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ('https',) or parsed.hostname not in _ALLOWED_STEAMGRIDDB_HOSTS:
+            return Response(status=400, response='url must be a SteamGridDB asset URL.')
+    except Exception:
+        return Response(status=400, response='Invalid url.')
+
     game = GameMetadata.query.filter_by(steamgriddb_id=steamgriddb_id).first()
     if not game:
         return Response(status=404, response='Game not found.')
@@ -1716,27 +1729,25 @@ def update_game_asset(steamgriddb_id):
     asset_dir = paths['data'] / 'game_assets' / str(steamgriddb_id)
     asset_dir.mkdir(parents=True, exist_ok=True)
 
-    # Remove existing files for this slot (any extension)
-    for existing in asset_dir.glob(f'{base_name}.*'):
-        try:
-            existing.unlink()
-        except OSError as e:
-            current_app.logger.warning(f'Could not remove old asset {existing}: {e}')
-
     dest_path = asset_dir / f'{base_name}{ext}'
 
-    # Download to temp file first, then move to final location
+    # Download to temp file first — do NOT remove the old asset until success
+    import shutil
     temp_dir = Path(tempfile.mkdtemp())
     try:
         temp_path = temp_dir / f'{base_name}{ext}'
         success = client._download_asset(url, temp_path)
         if not success:
             return Response(status=502, response='Failed to download asset from SteamGridDB.')
-        import shutil
+        # Download succeeded — now atomically replace: remove old, move new into place
+        for existing in asset_dir.glob(f'{base_name}.*'):
+            try:
+                existing.unlink()
+            except OSError as e:
+                current_app.logger.warning(f'Could not remove old asset {existing}: {e}')
         shutil.move(str(temp_path), str(dest_path))
     finally:
         if temp_dir.exists():
-            import shutil
             shutil.rmtree(temp_dir)
 
     return Response(status=200)

--- a/app/server/fireshare/models.py
+++ b/app/server/fireshare/models.py
@@ -117,10 +117,13 @@ class GameMetadata(db.Model):
         logo_url = None
         icon_url = None
 
+        banner_url = None
+
         if self.steamgriddb_id:
             domain = f"https://{current_app.config['DOMAIN']}" if current_app.config.get('DOMAIN') else ""
             # Assume standard .png extension - endpoint handles if missing or different
             hero_url = f"{domain}/api/game/assets/{self.steamgriddb_id}/hero_1.png"
+            banner_url = f"{domain}/api/game/assets/{self.steamgriddb_id}/hero_2.png"
             logo_url = f"{domain}/api/game/assets/{self.steamgriddb_id}/logo_1.png"
             icon_url = f"{domain}/api/game/assets/{self.steamgriddb_id}/icon_1.png"
 
@@ -130,6 +133,7 @@ class GameMetadata(db.Model):
             "name": self.name,
             "release_date": self.release_date,
             "hero_url": hero_url,
+            "banner_url": banner_url,
             "logo_url": logo_url,
             "icon_url": icon_url,
         }

--- a/app/server/fireshare/steamgrid.py
+++ b/app/server/fireshare/steamgrid.py
@@ -151,6 +151,26 @@ class SteamGridDBClient:
             logger.error(f"Error fetching icons for game {game_id}: {e}")
             return []
 
+    def get_all_asset_options(self, game_id: int, limit: int = 8) -> Dict:
+        """
+        Get multiple asset options for each type for manual selection
+
+        Args:
+            game_id: SteamGridDB game ID
+            limit: Max options to return per type
+
+        Returns:
+            Dictionary with heroes, logos, icons as lists of {id, url, thumb}
+        """
+        def extract(items):
+            return [{"id": item.get("id"), "url": item.get("url"), "thumb": item.get("thumb")} for item in items]
+
+        return {
+            "heroes": extract(self.get_heroes(game_id, limit=limit)),
+            "logos": extract(self.get_logos(game_id, limit=limit)),
+            "icons": extract(self.get_icons(game_id, limit=limit)),
+        }
+
     def get_game_assets(self, game_id: int) -> Dict:
         """
         Get all assets for a game (hero, logo, icon)


### PR DESCRIPTION
This PR adds the ability to manually change the assets for your games via SteamGridDB. If you're not happy with the ones that are auto picked, you can now manually select other available assets for your games via the edit button. 

https://github.com/user-attachments/assets/bb0596b4-8372-49c7-a46b-800953214bba

`GameVideos.js` Banner and `Game.js` Thumbnail are independent of each other, so both can be changed independently.

• Added `EditGameAssetsModal.js,` a new client service calls in GameService.js, and new backend routes in api.py plus multi-option asset 
• Manual asset updates now validate SteamGridDB hosts only, download to temp first, then replace the stored asset. This is to prevent arbitrary fetching of external urls that might not be SteamGridDB related.
• Updated `Games.js` to accommodate new edit mode. 
• Updated `GameVideos.js` to accommodate new edit mode. The banner will now dim and show an edit button to signify you're able to change assets.
• Updated `CompactVideoCards.js` so icon URLs refresh immediately after asset edits via a gameAssetsUpdated window event.

A lot more files were touched but this was mostly just wiring them up to refresh upon an asset change. Let me know if any questions :) 