### PR TITLE
Switch to SVT encoder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /tmp
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    cmake \
     pkg-config \
     yasm \
     nasm \
@@ -33,6 +34,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libfreetype6-dev \
     libmp3lame-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Build SVT-AV1 from source, V1.8.0 for FFmpeg 6.1
+RUN git clone --depth 1 --branch v1.8.0 https://gitlab.com/AOMediaCodec/SVT-AV1.git && \
+    cd SVT-AV1/Build && \
+    cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release && \
+    make -j$(nproc) && \
+    make install
 
 # Install NVIDIA codec headers for NVENC support
 RUN git clone --depth 1 --branch n12.1.14.0 https://github.com/FFmpeg/nv-codec-headers.git && \
@@ -61,6 +69,7 @@ RUN cd ffmpeg-6.1 && \
         --enable-libmp3lame \
         --enable-libass \
         --enable-libfreetype \
+        --enable-libsvtav1 \
         --disable-debug \
         --disable-doc
 
@@ -72,7 +81,7 @@ RUN cd ffmpeg-6.1 && \
 
 # Verify FFmpeg was built correctly
 RUN ffmpeg -version && \
-    ffmpeg -hide_banner -encoders 2>/dev/null | grep -E "(nvenc|264|265|vpx|aom)" | head -20
+    ffmpeg -hide_banner -encoders 2>/dev/null | grep -E "(nvenc|264|265|vpx|aom|svt)" | head -20
 
 # Main application stage
 FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -567,10 +567,10 @@ def _get_encoder_candidates(use_gpu=False, encoder_preference='auto'):
     }
     av1_cpu = {
         'name': 'AV1 CPU',
-        'video_codec': 'libaom-av1',
+        'video_codec': 'libsvtav1',
         'audio_codec': 'libopus',
         'audio_bitrate': '96k',
-        'extra_args': ['-cpu-used', '4', '-crf', '30', '-b:v', '0']
+        'extra_args': ['-preset', '6', '-crf', '30', '-b:v', '0', '-movflags', '+faststart']
     }
     h264_nvenc = {
         'name': 'H.264 NVENC',


### PR DESCRIPTION
This adds the libsvtav1 encoder to the ffmpeg build, and modifies util.py to use it instead of libaom.

I have already noticed that transcodes sometimes fail and produce corrupt files, so this should be combined with the change introducing temporary transcode output files before going out to users.

I was not able to reproduce the problem with manual transcodes. They always completed and produced intact files. So the current assumption is that the problem is with how the ffmpeg process is handled.

Transcoding performance on multiple cores is MUCH faster with this change.