### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,18 @@ If you update models, create a migration and review it before opening a pull req
 
 See [TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) for a full guide covering installation issues, playback problems, permission errors, transcoding, LDAP, and more.
 
+## Star History
+
+If you like the project consider giving it a star. Stars help increase visibility which in turn helps me improve the application.
+
+<a href="https://www.star-history.com/?repos=shaneisrael%2Ffireshare&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=shaneisrael/fireshare&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=shaneisrael/fireshare&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=shaneisrael/fireshare&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ---
 
 [card-view]: .github/images/card-view.png

--- a/app/client/src/components/admin/ImageFileManager.js
+++ b/app/client/src/components/admin/ImageFileManager.js
@@ -471,6 +471,17 @@ export default function ImageFileManager({ setAlert }) {
 
   const selectedCount = selected.size + selectedFolders.size
 
+  const onlyEmptyFoldersSelected = useMemo(
+    () =>
+      selected.size === 0 &&
+      selectedFolders.size > 0 &&
+      [...selectedFolders].every((f) => {
+        const pair = groupedFiles.find(([folder]) => folder === f)
+        return !pair || pair[1].length === 0
+      }),
+    [selected, selectedFolders, groupedFiles],
+  )
+
   const handleSort = (column) => {
     if (sortColumn === column) {
       setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
@@ -689,81 +700,93 @@ export default function ImageFileManager({ setAlert }) {
             border: '1px solid #3399FF33',
           }}
         >
-          <Typography variant="body2" sx={{ color: '#FFFFFFCC', whiteSpace: 'nowrap', mb: isMobile ? 1 : 0 }}>
-            {selectedCount} selected
-          </Typography>
+          {!onlyEmptyFoldersSelected && (
+            <Typography variant="body2" sx={{ color: '#FFFFFFCC', whiteSpace: 'nowrap', mb: isMobile ? 1 : 0 }}>
+              {selectedCount} selected
+            </Typography>
+          )}
 
           {isMobile ? (
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
               <Tooltip title="Move to folder">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setMoveTargetFolder(null)
-                    setMoveModalOpen(true)
-                  }}
-                  sx={{
-                    border: '1px solid #3399FF44',
-                    borderRadius: 1,
-                    color: '#7FBFFF',
-                    '&:hover': { bgcolor: '#3399FF12' },
-                  }}
-                >
-                  <DriveFileMoveIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled={onlyEmptyFoldersSelected}
+                    onClick={() => {
+                      setMoveTargetFolder(null)
+                      setMoveModalOpen(true)
+                    }}
+                    sx={{
+                      border: '1px solid #3399FF44',
+                      borderRadius: 1,
+                      color: '#7FBFFF',
+                      '&:hover': { bgcolor: '#3399FF12' },
+                    }}
+                  >
+                    <DriveFileMoveIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Rename">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setRenameOp({ value: 'find_replace', label: 'Find & Replace' })
-                    setRenameFind(
-                      selectedFiles.length === 1 ? selectedFiles[0].title || selectedFiles[0].filename || '' : '',
-                    )
-                    setRenameReplace('')
-                    setRenamePrefix('')
-                    setRenameSuffix('')
-                    setRenameDialogOpen(true)
-                  }}
-                  sx={{
-                    border: '1px solid #3399FF44',
-                    borderRadius: 1,
-                    color: '#7FBFFF',
-                    '&:hover': { bgcolor: '#3399FF12' },
-                  }}
-                >
-                  <DriveFileRenameOutlineIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled={onlyEmptyFoldersSelected}
+                    onClick={() => {
+                      setRenameOp({ value: 'find_replace', label: 'Find & Replace' })
+                      setRenameFind(
+                        selectedFiles.length === 1 ? selectedFiles[0].title || selectedFiles[0].filename || '' : '',
+                      )
+                      setRenameReplace('')
+                      setRenamePrefix('')
+                      setRenameSuffix('')
+                      setRenameDialogOpen(true)
+                    }}
+                    sx={{
+                      border: '1px solid #3399FF44',
+                      borderRadius: 1,
+                      color: '#7FBFFF',
+                      '&:hover': { bgcolor: '#3399FF12' },
+                    }}
+                  >
+                    <DriveFileRenameOutlineIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Set public">
-                <IconButton
-                  size="small"
-                  onClick={() => handleSetPrivacy(false)}
-                  disabled={actionLoading}
-                  sx={{
-                    border: '1px solid #1DB95444',
-                    borderRadius: 1,
-                    color: '#1DB954',
-                    '&:hover': { bgcolor: '#1DB95412' },
-                  }}
-                >
-                  <LockOpenIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleSetPrivacy(false)}
+                    disabled={onlyEmptyFoldersSelected || actionLoading}
+                    sx={{
+                      border: '1px solid #1DB95444',
+                      borderRadius: 1,
+                      color: '#1DB954',
+                      '&:hover': { bgcolor: '#1DB95412' },
+                    }}
+                  >
+                    <LockOpenIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Set private">
-                <IconButton
-                  size="small"
-                  onClick={() => handleSetPrivacy(true)}
-                  disabled={actionLoading}
-                  sx={{
-                    border: '1px solid #FFFFFF33',
-                    borderRadius: 1,
-                    color: '#FFFFFFCC',
-                    '&:hover': { bgcolor: '#FFFFFF0D' },
-                  }}
-                >
-                  <LockIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleSetPrivacy(true)}
+                    disabled={onlyEmptyFoldersSelected || actionLoading}
+                    sx={{
+                      border: '1px solid #FFFFFF33',
+                      borderRadius: 1,
+                      color: '#FFFFFFCC',
+                      '&:hover': { bgcolor: '#FFFFFF0D' },
+                    }}
+                  >
+                    <LockIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Delete selected">
                 <IconButton
@@ -785,48 +808,54 @@ export default function ImageFileManager({ setAlert }) {
               {/* Group 1: Organize */}
               <Box sx={{ display: 'flex', gap: '12px' }}>
                 <Tooltip title="Move selected to another folder">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<DriveFileMoveIcon />}
-                    onClick={() => {
-                      setMoveTargetFolder(null)
-                      setMoveModalOpen(true)
-                    }}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#3399FF44',
-                      color: '#7FBFFF',
-                      '&:hover': { borderColor: '#3399FF99', bgcolor: '#3399FF12' },
-                    }}
-                  >
-                    Move
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={onlyEmptyFoldersSelected}
+                      startIcon={<DriveFileMoveIcon />}
+                      onClick={() => {
+                        setMoveTargetFolder(null)
+                        setMoveModalOpen(true)
+                      }}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#3399FF44',
+                        color: '#7FBFFF',
+                        '&:hover': { borderColor: '#3399FF99', bgcolor: '#3399FF12' },
+                      }}
+                    >
+                      Move
+                    </Button>
+                  </span>
                 </Tooltip>
                 <Tooltip title="Rename selected images">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<DriveFileRenameOutlineIcon />}
-                    onClick={() => {
-                      setRenameOp({ value: 'find_replace', label: 'Find & Replace' })
-                      setRenameFind(
-                        selectedFiles.length === 1 ? selectedFiles[0].title || selectedFiles[0].filename || '' : '',
-                      )
-                      setRenameReplace('')
-                      setRenamePrefix('')
-                      setRenameSuffix('')
-                      setRenameDialogOpen(true)
-                    }}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#3399FF44',
-                      color: '#7FBFFF',
-                      '&:hover': { borderColor: '#3399FF99', bgcolor: '#3399FF12' },
-                    }}
-                  >
-                    Rename
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={onlyEmptyFoldersSelected}
+                      startIcon={<DriveFileRenameOutlineIcon />}
+                      onClick={() => {
+                        setRenameOp({ value: 'find_replace', label: 'Find & Replace' })
+                        setRenameFind(
+                          selectedFiles.length === 1 ? selectedFiles[0].title || selectedFiles[0].filename || '' : '',
+                        )
+                        setRenameReplace('')
+                        setRenamePrefix('')
+                        setRenameSuffix('')
+                        setRenameDialogOpen(true)
+                      }}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#3399FF44',
+                        color: '#7FBFFF',
+                        '&:hover': { borderColor: '#3399FF99', bgcolor: '#3399FF12' },
+                      }}
+                    >
+                      Rename
+                    </Button>
+                  </span>
                 </Tooltip>
               </Box>
 
@@ -835,38 +864,42 @@ export default function ImageFileManager({ setAlert }) {
               {/* Group 2: Privacy */}
               <Box sx={{ display: 'flex', gap: '12px' }}>
                 <Tooltip title="Make selected images public">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<LockOpenIcon />}
-                    onClick={() => handleSetPrivacy(false)}
-                    disabled={actionLoading}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#1DB95444',
-                      color: '#1DB954',
-                      '&:hover': { borderColor: '#1DB954', bgcolor: '#1DB95412' },
-                    }}
-                  >
-                    Set Public
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<LockOpenIcon />}
+                      onClick={() => handleSetPrivacy(false)}
+                      disabled={onlyEmptyFoldersSelected || actionLoading}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#1DB95444',
+                        color: '#1DB954',
+                        '&:hover': { borderColor: '#1DB954', bgcolor: '#1DB95412' },
+                      }}
+                    >
+                      Set Public
+                    </Button>
+                  </span>
                 </Tooltip>
                 <Tooltip title="Make selected images private">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<LockIcon />}
-                    onClick={() => handleSetPrivacy(true)}
-                    disabled={actionLoading}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#FFFFFF33',
-                      color: '#FFFFFFCC',
-                      '&:hover': { borderColor: '#FFFFFF66', bgcolor: '#FFFFFF0D' },
-                    }}
-                  >
-                    Set Private
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<LockIcon />}
+                      onClick={() => handleSetPrivacy(true)}
+                      disabled={onlyEmptyFoldersSelected || actionLoading}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#FFFFFF33',
+                        color: '#FFFFFFCC',
+                        '&:hover': { borderColor: '#FFFFFF66', bgcolor: '#FFFFFF0D' },
+                      }}
+                    >
+                      Set Private
+                    </Button>
+                  </span>
                 </Tooltip>
               </Box>
 

--- a/app/client/src/components/admin/VideoFileManager.js
+++ b/app/client/src/components/admin/VideoFileManager.js
@@ -602,6 +602,17 @@ export default function VideoFileManager({ setAlert }) {
 
   const selectedCount = selected.size + selectedFolders.size
 
+  const onlyEmptyFoldersSelected = useMemo(
+    () =>
+      selected.size === 0 &&
+      selectedFolders.size > 0 &&
+      [...selectedFolders].every((f) => {
+        const pair = groupedFiles.find(([folder]) => folder === f)
+        return !pair || pair[1].length === 0
+      }),
+    [selected, selectedFolders, groupedFiles],
+  )
+
   const handleSort = (column) => {
     if (sortColumn === column) {
       setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
@@ -887,110 +898,128 @@ export default function VideoFileManager({ setAlert }) {
             border: '1px solid #3399FF33',
           }}
         >
-          <Typography variant="body2" sx={{ color: '#FFFFFFCC', whiteSpace: 'nowrap', mb: isMobile ? 1 : 0 }}>
-            {selectedCount} selected
-          </Typography>
+          {!onlyEmptyFoldersSelected && (
+            <Typography variant="body2" sx={{ color: '#FFFFFFCC', whiteSpace: 'nowrap', mb: isMobile ? 1 : 0 }}>
+              {selectedCount} selected
+            </Typography>
+          )}
 
           {isMobile ? (
             /* Mobile: icon-only buttons in a compact wrap row */
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
               <Tooltip title="Move to folder">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setMoveTargetFolder(null)
-                    setMoveModalOpen(true)
-                  }}
-                  sx={{
-                    border: '1px solid #3399FF44',
-                    borderRadius: 1,
-                    color: '#7FBFFF',
-                    '&:hover': { bgcolor: '#3399FF12' },
-                  }}
-                >
-                  <DriveFileMoveIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled={onlyEmptyFoldersSelected}
+                    onClick={() => {
+                      setMoveTargetFolder(null)
+                      setMoveModalOpen(true)
+                    }}
+                    sx={{
+                      border: '1px solid #3399FF44',
+                      borderRadius: 1,
+                      color: '#7FBFFF',
+                      '&:hover': { bgcolor: '#3399FF12' },
+                    }}
+                  >
+                    <DriveFileMoveIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Rename">
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setRenameOp({ value: 'find_replace', label: 'Find & Replace' })
-                    setRenameFind(
-                      selectedFiles.length === 1 ? selectedFiles[0].title || selectedFiles[0].filename || '' : '',
-                    )
-                    setRenameReplace('')
-                    setRenamePrefix('')
-                    setRenameSuffix('')
-                    setRenameDialogOpen(true)
-                  }}
-                  sx={{
-                    border: '1px solid #3399FF44',
-                    borderRadius: 1,
-                    color: '#7FBFFF',
-                    '&:hover': { bgcolor: '#3399FF12' },
-                  }}
-                >
-                  <DriveFileRenameOutlineIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled={onlyEmptyFoldersSelected}
+                    onClick={() => {
+                      setRenameOp({ value: 'find_replace', label: 'Find & Replace' })
+                      setRenameFind(
+                        selectedFiles.length === 1 ? selectedFiles[0].title || selectedFiles[0].filename || '' : '',
+                      )
+                      setRenameReplace('')
+                      setRenamePrefix('')
+                      setRenameSuffix('')
+                      setRenameDialogOpen(true)
+                    }}
+                    sx={{
+                      border: '1px solid #3399FF44',
+                      borderRadius: 1,
+                      color: '#7FBFFF',
+                      '&:hover': { bgcolor: '#3399FF12' },
+                    }}
+                  >
+                    <DriveFileRenameOutlineIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Remove transcodes">
-                <IconButton
-                  size="small"
-                  onClick={() => setRemoveTranscodesDialogOpen(true)}
-                  sx={{
-                    border: '1px solid #FF990044',
-                    borderRadius: 1,
-                    color: '#FFBB66',
-                    '&:hover': { bgcolor: '#FF990012' },
-                  }}
-                >
-                  <VideoSettingsIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled={onlyEmptyFoldersSelected}
+                    onClick={() => setRemoveTranscodesDialogOpen(true)}
+                    sx={{
+                      border: '1px solid #FF990044',
+                      borderRadius: 1,
+                      color: '#FFBB66',
+                      '&:hover': { bgcolor: '#FF990012' },
+                    }}
+                  >
+                    <VideoSettingsIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Remove crop">
-                <IconButton
-                  size="small"
-                  onClick={() => setRemoveCropDialogOpen(true)}
-                  sx={{
-                    border: '1px solid #FF990044',
-                    borderRadius: 1,
-                    color: '#FFBB66',
-                    '&:hover': { bgcolor: '#FF990012' },
-                  }}
-                >
-                  <ContentCutIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled={onlyEmptyFoldersSelected}
+                    onClick={() => setRemoveCropDialogOpen(true)}
+                    sx={{
+                      border: '1px solid #FF990044',
+                      borderRadius: 1,
+                      color: '#FFBB66',
+                      '&:hover': { bgcolor: '#FF990012' },
+                    }}
+                  >
+                    <ContentCutIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Set public">
-                <IconButton
-                  size="small"
-                  onClick={() => handleSetPrivacy(false)}
-                  disabled={actionLoading}
-                  sx={{
-                    border: '1px solid #1DB95444',
-                    borderRadius: 1,
-                    color: '#1DB954',
-                    '&:hover': { bgcolor: '#1DB95412' },
-                  }}
-                >
-                  <LockOpenIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleSetPrivacy(false)}
+                    disabled={onlyEmptyFoldersSelected || actionLoading}
+                    sx={{
+                      border: '1px solid #1DB95444',
+                      borderRadius: 1,
+                      color: '#1DB954',
+                      '&:hover': { bgcolor: '#1DB95412' },
+                    }}
+                  >
+                    <LockOpenIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Set private">
-                <IconButton
-                  size="small"
-                  onClick={() => handleSetPrivacy(true)}
-                  disabled={actionLoading}
-                  sx={{
-                    border: '1px solid #FFFFFF33',
-                    borderRadius: 1,
-                    color: '#FFFFFFCC',
-                    '&:hover': { bgcolor: '#FFFFFF0D' },
-                  }}
-                >
-                  <LockIcon sx={{ fontSize: 20 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleSetPrivacy(true)}
+                    disabled={onlyEmptyFoldersSelected || actionLoading}
+                    sx={{
+                      border: '1px solid #FFFFFF33',
+                      borderRadius: 1,
+                      color: '#FFFFFFCC',
+                      '&:hover': { bgcolor: '#FFFFFF0D' },
+                    }}
+                  >
+                    <LockIcon sx={{ fontSize: 20 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
               <Tooltip title="Delete selected">
                 <IconButton
@@ -1013,48 +1042,54 @@ export default function VideoFileManager({ setAlert }) {
               {/* Group 1: Organize */}
               <Box sx={{ display: 'flex', gap: '12px' }}>
                 <Tooltip title="Move selected to another folder">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<DriveFileMoveIcon />}
-                    onClick={() => {
-                      setMoveTargetFolder(null)
-                      setMoveModalOpen(true)
-                    }}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#3399FF44',
-                      color: '#7FBFFF',
-                      '&:hover': { borderColor: '#3399FF99', bgcolor: '#3399FF12' },
-                    }}
-                  >
-                    Move
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={onlyEmptyFoldersSelected}
+                      startIcon={<DriveFileMoveIcon />}
+                      onClick={() => {
+                        setMoveTargetFolder(null)
+                        setMoveModalOpen(true)
+                      }}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#3399FF44',
+                        color: '#7FBFFF',
+                        '&:hover': { borderColor: '#3399FF99', bgcolor: '#3399FF12' },
+                      }}
+                    >
+                      Move
+                    </Button>
+                  </span>
                 </Tooltip>
                 <Tooltip title="Rename selected files">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<DriveFileRenameOutlineIcon />}
-                    onClick={() => {
-                      setRenameOp({ value: 'find_replace', label: 'Find & Replace' })
-                      setRenameFind(
-                        selectedFiles.length === 1 ? selectedFiles[0].title || selectedFiles[0].filename || '' : '',
-                      )
-                      setRenameReplace('')
-                      setRenamePrefix('')
-                      setRenameSuffix('')
-                      setRenameDialogOpen(true)
-                    }}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#3399FF44',
-                      color: '#7FBFFF',
-                      '&:hover': { borderColor: '#3399FF99', bgcolor: '#3399FF12' },
-                    }}
-                  >
-                    Rename
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={onlyEmptyFoldersSelected}
+                      startIcon={<DriveFileRenameOutlineIcon />}
+                      onClick={() => {
+                        setRenameOp({ value: 'find_replace', label: 'Find & Replace' })
+                        setRenameFind(
+                          selectedFiles.length === 1 ? selectedFiles[0].title || selectedFiles[0].filename || '' : '',
+                        )
+                        setRenameReplace('')
+                        setRenamePrefix('')
+                        setRenameSuffix('')
+                        setRenameDialogOpen(true)
+                      }}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#3399FF44',
+                        color: '#7FBFFF',
+                        '&:hover': { borderColor: '#3399FF99', bgcolor: '#3399FF12' },
+                      }}
+                    >
+                      Rename
+                    </Button>
+                  </span>
                 </Tooltip>
               </Box>
 
@@ -1063,36 +1098,42 @@ export default function VideoFileManager({ setAlert }) {
               {/* Group 2: Cleanup */}
               <Box sx={{ display: 'flex', gap: '12px' }}>
                 <Tooltip title="Remove transcoded versions (480p / 720p / 1080p)">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<VideoSettingsIcon />}
-                    onClick={() => setRemoveTranscodesDialogOpen(true)}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#FF990044',
-                      color: '#FFBB66',
-                      '&:hover': { borderColor: '#FF990099', bgcolor: '#FF990012' },
-                    }}
-                  >
-                    Remove Transcodes
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={onlyEmptyFoldersSelected}
+                      startIcon={<VideoSettingsIcon />}
+                      onClick={() => setRemoveTranscodesDialogOpen(true)}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#FF990044',
+                        color: '#FFBB66',
+                        '&:hover': { borderColor: '#FF990099', bgcolor: '#FF990012' },
+                      }}
+                    >
+                      Remove Transcodes
+                    </Button>
+                  </span>
                 </Tooltip>
                 <Tooltip title="Remove crop settings from selected files">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<ContentCutIcon />}
-                    onClick={() => setRemoveCropDialogOpen(true)}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#FF990044',
-                      color: '#FFBB66',
-                      '&:hover': { borderColor: '#FF990099', bgcolor: '#FF990012' },
-                    }}
-                  >
-                    Remove Crop
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      disabled={onlyEmptyFoldersSelected}
+                      startIcon={<ContentCutIcon />}
+                      onClick={() => setRemoveCropDialogOpen(true)}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#FF990044',
+                        color: '#FFBB66',
+                        '&:hover': { borderColor: '#FF990099', bgcolor: '#FF990012' },
+                      }}
+                    >
+                      Remove Crop
+                    </Button>
+                  </span>
                 </Tooltip>
               </Box>
 
@@ -1101,38 +1142,42 @@ export default function VideoFileManager({ setAlert }) {
               {/* Group 3: Privacy */}
               <Box sx={{ display: 'flex', gap: '12px' }}>
                 <Tooltip title="Make selected files public">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<LockOpenIcon />}
-                    onClick={() => handleSetPrivacy(false)}
-                    disabled={actionLoading}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#1DB95444',
-                      color: '#1DB954',
-                      '&:hover': { borderColor: '#1DB954', bgcolor: '#1DB95412' },
-                    }}
-                  >
-                    Set Public
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<LockOpenIcon />}
+                      onClick={() => handleSetPrivacy(false)}
+                      disabled={onlyEmptyFoldersSelected || actionLoading}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#1DB95444',
+                        color: '#1DB954',
+                        '&:hover': { borderColor: '#1DB954', bgcolor: '#1DB95412' },
+                      }}
+                    >
+                      Set Public
+                    </Button>
+                  </span>
                 </Tooltip>
                 <Tooltip title="Make selected files private">
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    startIcon={<LockIcon />}
-                    onClick={() => handleSetPrivacy(true)}
-                    disabled={actionLoading}
-                    sx={{
-                      textTransform: 'none',
-                      borderColor: '#FFFFFF33',
-                      color: '#FFFFFFCC',
-                      '&:hover': { borderColor: '#FFFFFF66', bgcolor: '#FFFFFF0D' },
-                    }}
-                  >
-                    Set Private
-                  </Button>
+                  <span>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<LockIcon />}
+                      onClick={() => handleSetPrivacy(true)}
+                      disabled={onlyEmptyFoldersSelected || actionLoading}
+                      sx={{
+                        textTransform: 'none',
+                        borderColor: '#FFFFFF33',
+                        color: '#FFFFFFCC',
+                        '&:hover': { borderColor: '#FFFFFF66', bgcolor: '#FFFFFF0D' },
+                      }}
+                    >
+                      Set Private
+                    </Button>
+                  </span>
                 </Tooltip>
               </Box>
 

--- a/app/nginx/prod.conf
+++ b/app/nginx/prod.conf
@@ -150,21 +150,42 @@ http {
             add_header              X-Accel-Buffering "no";
         }
 
-        location ~ /api/.*$ {
+        location ~ ^/api/game/assets/ {
             proxy_pass              http://127.0.0.1:5000;
             proxy_http_version      1.1;
-            
+
             proxy_set_header        Connection "";
             proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header        X-Real-IP $remote_addr;
             proxy_set_header        Host $http_host;
             proxy_set_header        X-Forwarded-Proto $scheme;
-            
+
+            proxy_buffering on;
+            proxy_buffer_size 256k;
+            proxy_buffers 8 256k;
+            proxy_busy_buffers_size 512k;
+
+            proxy_connect_timeout   60s;
+            proxy_send_timeout      120s;
+            proxy_read_timeout      60s;
+            client_max_body_size 0;
+        }
+
+        location ~ /api/.*$ {
+            proxy_pass              http://127.0.0.1:5000;
+            proxy_http_version      1.1;
+
+            proxy_set_header        Connection "";
+            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Real-IP $remote_addr;
+            proxy_set_header        Host $http_host;
+            proxy_set_header        X-Forwarded-Proto $scheme;
+
             proxy_buffering on;
             proxy_buffer_size 4k;
             proxy_buffers 8 4k;
             proxy_busy_buffers_size 8k;
-            
+
             proxy_connect_timeout   60s;
             proxy_send_timeout      120s;
             proxy_read_timeout      999999s;

--- a/app/nginx/prod.conf
+++ b/app/nginx/prod.conf
@@ -22,7 +22,7 @@ http {
                       '"$http_user_agent" "$remote_addr"';
 
     server_tokens off;
-    access_log  /var/log/nginx/access.log  main;
+    access_log  off;
 
     sendfile        on;
     sendfile_max_chunk 2m;

--- a/app/server/fireshare/auth.py
+++ b/app/server/fireshare/auth.py
@@ -146,7 +146,7 @@ def loggedin():
             if release_is_old_enough:
                 latest_release = release_data
         else:
-            current_app.logger.info(f"Fireshare is up to date (v{local_version}).")
+            pass
 
     return jsonify({
         'authenticated': True,

--- a/app/server/gunicorn.conf.py
+++ b/app/server/gunicorn.conf.py
@@ -19,8 +19,8 @@ graceful_timeout = 30
 keepalive = 5  # Keep connections alive
 
 # Logging
-loglevel = "info"
-accesslog = "-"  # Log to stdout
+loglevel = "warning"
+accesslog = None
 errorlog = "-"   # Log to stderr
 access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s'
 


### PR DESCRIPTION
This pull request improves the user experience in both the `ImageFileManager` and `VideoFileManager` admin components by preventing bulk actions when only empty folders are selected. It introduces a new check to disable action buttons if the selection contains only empty folders, ensuring that actions like move, rename, privacy changes, and cleanup are only available when applicable. Additionally, it wraps disabled buttons in `<span>` elements to maintain proper tooltip behavior. The README is also updated with a "Star History" section.

**Bulk Action Button Improvements:**

* Added a new `onlyEmptyFoldersSelected` check in both `ImageFileManager.js` and `VideoFileManager.js` to determine if only empty folders are selected, and used this to disable all bulk action buttons (move, rename, privacy, cleanup, etc.) when appropriate. [[1]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR474-R484) [[2]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R605-R615)
* Wrapped action buttons in `<span>` elements when disabled to ensure tooltips remain visible even when the button cannot be interacted with. [[1]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR703-R715) [[2]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR729-R735) [[3]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR755-R762) [[4]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR772-R779) [[5]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR789) [[6]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR811-R815) [[7]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR830-R837) [[8]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR858) [[9]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR867-R873) [[10]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR883-R892) [[11]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR902) [[12]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R901-R914) [[13]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R928-R934) [[14]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R954-R960) [[15]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R971-R977) [[16]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R988-R995) [[17]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R1005-R1012) [[18]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R1022) [[19]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R1045-R1049) [[20]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R1064-R1071) [[21]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R1092) [[22]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R1101-R1105) [[23]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R1117-R1124) [[24]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R1136)

**UI/UX Enhancements:**

* The "selected count" indicator is now hidden when only empty folders are selected, clarifying that no actionable files are chosen. [[1]](diffhunk://#diff-b64da561033148454799a11826963ff38e279950629fd452ce6f4dccf30fff7fR703-R715) [[2]](diffhunk://#diff-936e24b36aedd0ca240797a858c49eff0d5952d6c73def9148511bb4f6d35fe9R901-R914)

**Documentation:**

* Added a "Star History" section to `README.md` to encourage starring the project and show star growth over time.