### PR TITLE
Develop

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fireshare",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fireshare",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/app/server/fireshare/api/helpers.py
+++ b/app/server/fireshare/api/helpers.py
@@ -8,7 +8,7 @@ from ..models import Video
 
 
 def secure_filename(filename):
-    clean = re.sub(r"[/\\?%*:|\"<>\x7F\x00-\x1F]", "-", filename)
+    clean = re.sub(r"[/\\?%*:|\"<>\x7F\x00-\x1F\s]", "-", filename)
     return clean
 
 

--- a/app/server/fireshare/api/upload.py
+++ b/app/server/fireshare/api/upload.py
@@ -101,7 +101,7 @@ def public_upload_video():
     upload_folder = config['app_config']['public_upload_folder_name']
     if config['app_config'].get('allow_public_folder_selection', False):
         requested_folder = request.form.get('folder', '').strip()
-        if requested_folder and '/' not in requested_folder and '..' not in requested_folder:
+        if requested_folder and '/' not in requested_folder and '..' not in requested_folder and ' ' not in requested_folder:
             upload_folder = requested_folder
 
     if 'file' not in request.files:
@@ -174,7 +174,7 @@ def public_upload_videoChunked():
 
     if config['app_config'].get('allow_public_folder_selection', False):
         requested_folder = request.form.get('folder', '').strip()
-        if requested_folder and '/' not in requested_folder and '..' not in requested_folder:
+        if requested_folder and '/' not in requested_folder and '..' not in requested_folder and ' ' not in requested_folder:
             upload_folder = requested_folder
 
     upload_directory = paths['video'] / upload_folder
@@ -297,7 +297,7 @@ def upload_video():
 
     upload_folder = config['app_config']['admin_upload_folder_name']
     requested_folder = request.form.get('folder', '').strip()
-    if requested_folder and '/' not in requested_folder and '..' not in requested_folder:
+    if requested_folder and '/' not in requested_folder and '..' not in requested_folder and ' ' not in requested_folder:
         upload_folder = requested_folder
 
     if 'file' not in request.files:
@@ -341,7 +341,7 @@ def upload_videoChunked():
 
     upload_folder = config['app_config']['admin_upload_folder_name']
     requested_folder = request.form.get('folder', '').strip()
-    if requested_folder and '/' not in requested_folder and '..' not in requested_folder:
+    if requested_folder and '/' not in requested_folder and '..' not in requested_folder and ' ' not in requested_folder:
         upload_folder = requested_folder
 
     required_files = ['blob']

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -677,7 +677,7 @@ def create_posters(regenerate, skip):
             if should_create_poster:
                 if not derived_path.exists():
                     derived_path.mkdir(parents=True)
-                poster_time = int(vi.duration * skip)
+                poster_time = int((vi.duration or 0) * skip)
                 util.create_poster(video_path, derived_path / "poster.jpg", poster_time)
             else:
                 logger.debug(f"Skipping creation of poster for video {vi.video_id} because it exists at {str(poster_path)}")

--- a/app/server/fireshare/cli.py
+++ b/app/server/fireshare/cli.py
@@ -1182,8 +1182,8 @@ def scan_image(ctx, path, game_id, tag_ids, title):
             else:
                 logger.debug(f"Image {iid} already indexed")
         else:
-            created_at = datetime.fromtimestamp(os.path.getmtime(str(img_file)))
-            updated_at = datetime.fromtimestamp(os.path.getmtime(str(img_file)))
+            created_at = util.extract_date_from_image_file(img_file)
+            updated_at = created_at
             source_folder = rel_path.split('/')[0] if '/' in rel_path else None
             img = Image(image_id=iid, extension=img_file.suffix, path=rel_path,
                         available=True, created_at=created_at, updated_at=updated_at,

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -175,9 +175,9 @@ def video_id(path: Path, mb=16):
 
 def get_media_info(path):
     try:
-        cmd = f'ffprobe -v quiet -print_format json -show_entries stream {path}'
-        logger.debug(f"$ {cmd}")
-        data = json.loads(sp.check_output(cmd.split()).decode('utf-8'))
+        cmd = ['ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_entries', 'stream', str(path)]
+        logger.debug(f"$ {' '.join(cmd)}")
+        data = json.loads(sp.check_output(cmd).decode('utf-8'))
         return data['streams']
     except Exception as ex:
         logger.warning('Could not extract video info')
@@ -1361,9 +1361,9 @@ def _extract_date_from_metadata(file_path: Path):
         datetime object if a valid date was found in metadata, None otherwise
     """
     try:
-        cmd = f'ffprobe -v quiet -print_format json -show_entries format_tags {file_path}'
-        logger.debug(f"$ {cmd}")
-        data = json.loads(sp.check_output(cmd.split()).decode('utf-8'))
+        cmd = ['ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_entries', 'format_tags', str(file_path)]
+        logger.debug(f"$ {' '.join(cmd)}")
+        data = json.loads(sp.check_output(cmd).decode('utf-8'))
         
         tags = data.get('format', {}).get('tags', {})
         if not tags:

--- a/app/server/fireshare/util.py
+++ b/app/server/fireshare/util.py
@@ -1405,6 +1405,68 @@ def _extract_date_from_metadata(file_path: Path):
         return None
 
 
+def _extract_date_from_image_exif(file_path: Path):
+    """
+    Extract creation date from image EXIF metadata using PIL.
+
+    Checks DateTimeOriginal (36867), DateTimeDigitized (36868), and DateTime (306).
+    """
+    try:
+        from PIL import Image as PILImage
+        with PILImage.open(str(file_path)) as img:
+            exif_data = img._getexif()
+            if not exif_data:
+                return None
+        # EXIF tag IDs for date fields in priority order
+        for tag_id in (36867, 36868, 306):
+            value = exif_data.get(tag_id)
+            if value:
+                try:
+                    parsed = datetime.strptime(value, '%Y:%m:%d %H:%M:%S')
+                    if 2000 <= parsed.year <= datetime.now().year + 1:
+                        logger.debug(f"Extracted date {parsed} from image EXIF tag {tag_id}")
+                        return parsed
+                except ValueError:
+                    continue
+        return None
+    except Exception as ex:
+        logger.debug(f"Failed to extract EXIF date from image: {ex}")
+        return None
+
+
+def extract_date_from_image_file(file_path: Path):
+    """
+    Extract a creation date from an image file.
+
+    Tries in order:
+    1. EXIF metadata (DateTimeOriginal, DateTimeDigitized, DateTime)
+    2. Filename date patterns
+    3. File modification time
+    """
+    file_path = Path(file_path)
+
+    if not file_path.exists():
+        logger.warning(f"Cannot extract date from non-existent file: {file_path}")
+        return None
+
+    exif_date = _extract_date_from_image_exif(file_path)
+    if exif_date:
+        return exif_date
+
+    filename_date = _extract_date_from_filename(file_path.name)
+    if filename_date:
+        logger.debug(f"Using filename date for {file_path.name}: {filename_date}")
+        return filename_date
+
+    try:
+        created_date = datetime.fromtimestamp(os.path.getmtime(file_path))
+        logger.debug(f"Using file mtime for {file_path.name}: {created_date}")
+        return created_date
+    except Exception as ex:
+        logger.warning(f"Failed to get file mtime for {file_path}: {ex}")
+        return None
+
+
 def extract_date_from_file(file_path: Path):
     """
     Extract a recording date from a video file.


### PR DESCRIPTION
This pull request introduces a few targeted improvements to file upload validation, media metadata extraction, and utility robustness. The most significant changes are the stricter validation of folder names during uploads, enhanced extraction of image creation dates using EXIF metadata, and improved command construction for ffprobe invocations.

**File upload validation:**

* Tightened folder name validation in all upload endpoints (`public_upload_video`, `public_upload_videoChunked`, `upload_video`, `upload_videoChunked`) to reject folder names containing spaces, in addition to slashes and parent directory references. This helps prevent accidental or malicious folder naming issues. [[1]](diffhunk://#diff-f69e09d99ffced054afe97cd5c71fc89799af891bcc04d1055d3fa08af1d72ebL104-R104) [[2]](diffhunk://#diff-f69e09d99ffced054afe97cd5c71fc89799af891bcc04d1055d3fa08af1d72ebL177-R177) [[3]](diffhunk://#diff-f69e09d99ffced054afe97cd5c71fc89799af891bcc04d1055d3fa08af1d72ebL300-R300) [[4]](diffhunk://#diff-f69e09d99ffced054afe97cd5c71fc89799af891bcc04d1055d3fa08af1d72ebL344-R344)
* Updated `secure_filename` in `helpers.py` to replace whitespace characters with hyphens, further sanitizing filenames.

**Media metadata extraction and utility improvements:**

* Added robust extraction of image creation dates using EXIF metadata in `util.py` (`extract_date_from_image_file` and `_extract_date_from_image_exif`), with fallback to filename patterns and file modification time. Updated `scan_image` in `cli.py` to use this improved extraction method. [[1]](diffhunk://#diff-1c37e66b2c096812de110ec54f2f3f026292247b4a082d5c9772b2fa6ec5b57dR1408-R1469) [[2]](diffhunk://#diff-326b559662f48d754e3fa59a3d2dcb98263d3fbff881a1e9025770872faf7316L1185-R1186)
* Refactored ffprobe command construction in `get_media_info` and `_extract_date_from_metadata` to use argument lists instead of string splitting, improving reliability and error handling. [[1]](diffhunk://#diff-1c37e66b2c096812de110ec54f2f3f026292247b4a082d5c9772b2fa6ec5b57dL178-R180) [[2]](diffhunk://#diff-1c37e66b2c096812de110ec54f2f3f026292247b4a082d5c9772b2fa6ec5b57dL1364-R1366)

**Other improvements:**

* Fixed a bug in `create_posters` where a missing duration could cause a crash, by defaulting to zero if the video duration is `None`.
* Incremented the client version to `1.6.14` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-b8d2936a034f3ef827722f0cd18b81d5522b816bfe559ce499e8841f2142aeafL3-R3) [[2]](diffhunk://#diff-016a7181919dac607cf83c20085fd3c0e19bdbd6026c4cf88fc46fdc4c946833L3-R3)