### PR TITLE
Fix seek causing playback to reset to 0 and pause

### DIFF
--- a/app/client/src/components/player/VideoJSPlayer.js
+++ b/app/client/src/components/player/VideoJSPlayer.js
@@ -131,6 +131,7 @@ function PlayerEffects({ sources, onSourceChange, onTimeUpdate, onReady, startTi
     let bufferTimestamps = []
     let isSourceTransitioning = false
     let sourceTransitionTimer = null
+    let isSeeking = false
 
     const clearStallTimer = () => {
       if (bufferStallTimer) {
@@ -182,8 +183,21 @@ function PlayerEffects({ sources, onSourceChange, onTimeUpdate, onReady, startTi
       clearTransitionTimer()
     }
 
+    const handleSeeking = () => {
+      isSeeking = true
+      clearStallTimer()
+    }
+
+    const handleSeeked = () => {
+      isSeeking = false
+      clearStallTimer()
+    }
+
     const handleWaiting = () => {
-      if (isSourceTransitioning) return
+      // Seeking to an unbuffered position naturally fires 'waiting' while the
+      // browser loads that range — that's not real network stalling and
+      // shouldn't count toward a quality downgrade.
+      if (isSourceTransitioning || isSeeking) return
 
       const now = Date.now()
       bufferTimestamps.push(now)
@@ -213,7 +227,8 @@ function PlayerEffects({ sources, onSourceChange, onTimeUpdate, onReady, startTi
     media.addEventListener('waiting', handleWaiting)
     media.addEventListener('playing', handlePlayingOrPause)
     media.addEventListener('pause', handlePlayingOrPause)
-    media.addEventListener('seeked', handlePlayingOrPause)
+    media.addEventListener('seeking', handleSeeking)
+    media.addEventListener('seeked', handleSeeked)
 
     return () => {
       clearStallTimer()
@@ -224,7 +239,8 @@ function PlayerEffects({ sources, onSourceChange, onTimeUpdate, onReady, startTi
       media.removeEventListener('waiting', handleWaiting)
       media.removeEventListener('playing', handlePlayingOrPause)
       media.removeEventListener('pause', handlePlayingOrPause)
-      media.removeEventListener('seeked', handlePlayingOrPause)
+      media.removeEventListener('seeking', handleSeeking)
+      media.removeEventListener('seeked', handleSeeked)
     }
   }, [media, sources, onSourceChange])
 


### PR DESCRIPTION
Noticed an issue where on videos with multiple quality sources, seeking would sometimes cause playback to jump back to 0:00 and pause with a lower quality, like so:

https://github.com/user-attachments/assets/af259855-e132-4f76-90be-473e94b62bae

The reason for this is that the auto-quality-downgrade logic that's already existing watches the `waiting` event for real network stalls and drops to a lower-qual source when the connection can't keep up. Although this is normally good, the current problem is that seeking to an unbuffered position fires `waiting` as well, not having logic distinguishing between regular `waiting` events and simply seeking through the video. My fix was tracking a seek state via the `seeking`/`seeked` events and ignoring `waiting` when a seek is in progress. 

Here's the after:

https://github.com/user-attachments/assets/01556616-032d-495d-95b3-612e1ad380a8

Let me know what you think!