### PR TITLE
Fix browser/GPU crash caused by leaked video players when closing the video modal

### DIFF
--- a/app/client/src/components/modal/VideoModal.js
+++ b/app/client/src/components/modal/VideoModal.js
@@ -423,6 +423,9 @@ const VideoModal = ({
     if (!open) {
       clearInterval(cropPollRef.current)
       setCropProcessing(false)
+      // Drop the player wrapper so the unmounted <video> element it references
+      // can be garbage collected along with its decoder resources.
+      playerRef.current = null
     }
   }, [open])
 

--- a/app/client/src/components/player/VideoJSPlayer.js
+++ b/app/client/src/components/player/VideoJSPlayer.js
@@ -70,6 +70,22 @@ function PlayerEffects({ sources, onSourceChange, onTimeUpdate, onReady, startTi
     }
   }, [media, playerWrapper])
 
+  // --- teardown: release the media element's decoder/buffers on unmount ------
+  // React only removes the <video> node from the DOM; without an explicit src
+  // detach Chrome keeps the demuxer and hardware decoder pinned until GC,
+  // which accumulates across open/close cycles and can crash the GPU process.
+  useEffect(() => {
+    if (!media) return
+    return () => {
+      // isConnected is still true during StrictMode's simulated unmount —
+      // only tear down once the element has really left the DOM.
+      if (media.isConnected) return
+      media.pause()
+      media.removeAttribute('src')
+      media.load()
+    }
+  }, [media])
+
   // --- startTime: seek to the requested position once the player is ready ----
   useEffect(() => {
     if (!media || !startTime || startTimeApplied.current) return


### PR DESCRIPTION
Noticed an issue where browser would freeze up (usually when opening a video and then closing it and then opening a video again). Looks like the video player doesn't detach its source on unmount, so Chrome keeps the decoder pipeline pinned and open/close cycles for videos just piles up stranded players.

Made a new teardown effect such that when a media element leaves the DOM, it's paused, `src` is removed, and `load()` is called so that Chrome releases the decoder immediately.  Also clears `playerRef.current` when the modal closes so that the unmounted element can be collected.