### PR TITLE
Fix wrong touch device detection causing all videos card to automatically start under certain conditions

### DIFF
--- a/app/client/src/components/cards/CompactVideoCard.js
+++ b/app/client/src/components/cards/CompactVideoCard.js
@@ -114,7 +114,7 @@ const CompactVideoCard = ({
 
   const cardRef = React.useRef(null)
   const isTouchDevice = React.useRef(
-    typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0),
+    typeof window !== 'undefined' && window.matchMedia('(hover: none) and (pointer: coarse)').matches
   )
 
   React.useEffect(() => {


### PR DESCRIPTION
Fix for #690 

A simple commit that fixes all video cards displayed on screen starting at the same time, causing huge HDD load, under certain conditions.

Why the bug:  `navigator.maxTouchPoints` behaves differently on Chrome and Firefox - Chrome checks the current input device being used while Firefox checks all the devices available (via system drivers), returning false or true depending on the browser.

Users (like me) who has any tablet driver installed on their Windows will cause Firefox to return true. With `isTouchDevice` being true, the useEffect (CompactVideoCards:120) starts an IntersectionObserver causing every video that comes into view to automatically start - convenient on phone, but creating the issue #690.

My commit makes it so it checks the currently used input device and simply detects if it capable of hovering and has a fine pointer (CSS Level 4 media query).
