### PR TITLE
Stop lite digests leaking into full-image manifests

### DIFF
--- a/.github/workflows/docker-publish-develop.yml
+++ b/.github/workflows/docker-publish-develop.yml
@@ -264,7 +264,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: manual-digests-*
+          pattern: manual-digests-linux-*
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-publish-main.yml
+++ b/.github/workflows/docker-publish-main.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-linux-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -334,7 +334,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: manual-digests-*
+          pattern: manual-digests-linux-*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
The full-image merge jobs downloaded artifacts with the pattern digests-* / manual-digests-*, which also matched the lite build's digests-lite-* / manual-digests-lite-* artifacts whenever build-lite finished first. The resulting manifest list for latest, 1.7.9 and 1.7 contained both full and lite images per platform, and Docker resolved latest to the lite variant (#714).

Narrow the patterns to digests-linux-* / manual-digests-linux-* so only the full-image digests are merged, matching what the develop push workflow already does.