### PR TITLE
feat: Add private/public filter to videos view for authenticated user (develop branch)

### DIFF
--- a/app/client/src/common/constants.js
+++ b/app/client/src/common/constants.js
@@ -6,5 +6,10 @@ export const SORT_OPTIONS = [
   { value: 'name_asc', label: 'Name A→Z' },
   { value: 'name_desc', label: 'Name Z→A' },
 ]
+export const PRIVACY_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'public', label: 'Public' },
+  { value: 'private', label: 'Private' },
+]
 
 export const AUTH_REQUIRED_PAGES = ['/', '/settings']

--- a/app/client/src/views/Dashboard.js
+++ b/app/client/src/views/Dashboard.js
@@ -32,7 +32,7 @@ import TagChip from '../components/ui/TagChip'
 import { folderSelectTheme as selectFolderTheme } from '../common/reactSelectThemes'
 import OutlinedIconButton from '../components/ui/OutlinedIconButton'
 import MarqueeSingleValue, { MarqueeOption } from '../components/ui/MarqueeSingleValue'
-import { SORT_OPTIONS } from '../common/constants'
+import { SORT_OPTIONS, PRIVACY_OPTIONS } from '../common/constants'
 import { inputSx, dialogPaperSx, dialogTitleSx } from '../common/modalStyles'
 
 const Dashboard = ({
@@ -51,6 +51,7 @@ const Dashboard = ({
   const [folderList, setFolderList] = React.useState([])
   const [loading, setLoading] = React.useState(true)
   const [dateSortOrder, setDateSortOrder] = React.useState(SORT_OPTIONS?.[0] || { value: 'newest', label: 'Newest' })
+  const [privacyFilter, setPrivacyFilter] = React.useState(PRIVACY_OPTIONS[0])
 
   const [alert, setAlert] = React.useState({ open: false })
 
@@ -191,17 +192,18 @@ const Dashboard = ({
 
   // Get the filtered videos based on folder selection
   const displayVideos = React.useMemo(() => {
-    if (folder.value === 'All Videos') {
-      return filteredVideos
-    }
-    return filteredVideos?.filter(
-      (v) =>
-        v.path
-          .split('/')
-          .slice(0, -1)
-          .filter((f) => f !== '')[0] === folder.value,
-    )
-  }, [filteredVideos, folder])
+  if (!filteredVideos) return filteredVideos
+
+  const folderFiltered =
+    folder.value === 'All Videos'
+      ? filteredVideos
+      : filteredVideos.filter(
+          (v) => v.path.split('/').slice(0, -1).filter((f) => f !== '')[0] === folder.value,
+        )
+
+  if (privacyFilter.value === 'all') return folderFiltered
+  return folderFiltered.filter((v) => v.info?.private === (privacyFilter.value === 'private'))
+}, [filteredVideos, folder, privacyFilter])
 
   // Sort videos by recorded date or views
   const sortedVideos = React.useMemo(() => {
@@ -504,6 +506,20 @@ const Dashboard = ({
                     isSearchable={false}
                   />
                 </Box>
+                {authenticated && (
+                  <Box sx={{ minWidth: { xs: 110, sm: 130 } }}>
+                    <Select
+                      value={privacyFilter}
+                      options={PRIVACY_OPTIONS}
+                      onChange={setPrivacyFilter}
+                      styles={selectFolderTheme}
+                      menuPortalTarget={document.body}
+                      menuPosition="fixed"
+                      blurInputOnSelect
+                      isSearchable={false}
+                    />
+                  </Box>
+                )}
               </Box>
             )}
             {authenticated && (

--- a/app/client/src/views/Dashboard.js
+++ b/app/client/src/views/Dashboard.js
@@ -192,18 +192,22 @@ const Dashboard = ({
 
   // Get the filtered videos based on folder selection
   const displayVideos = React.useMemo(() => {
-  if (!filteredVideos) return filteredVideos
+    if (!filteredVideos) return filteredVideos
 
-  const folderFiltered =
-    folder.value === 'All Videos'
-      ? filteredVideos
-      : filteredVideos.filter(
-          (v) => v.path.split('/').slice(0, -1).filter((f) => f !== '')[0] === folder.value,
-        )
+    const folderFiltered =
+      folder.value === 'All Videos'
+        ? filteredVideos
+        : filteredVideos.filter(
+            (v) => 
+              v.path
+                .split('/')
+                .slice(0, -1)
+                .filter((f) => f !== '')[0] === folder.value,
+          )
 
-  if (privacyFilter.value === 'all') return folderFiltered
-  return folderFiltered.filter((v) => v.info?.private === (privacyFilter.value === 'private'))
-}, [filteredVideos, folder, privacyFilter])
+    if (privacyFilter.value === 'all') return folderFiltered
+    return folderFiltered.filter((v) => v.info?.private === (privacyFilter.value === 'private'))
+  }, [filteredVideos, folder, privacyFilter])
 
   // Sort videos by recorded date or views
   const sortedVideos = React.useMemo(() => {

--- a/app/client/src/views/ImageFeed.js
+++ b/app/client/src/views/ImageFeed.js
@@ -28,7 +28,7 @@ import SnackbarAlert from '../components/alert/SnackbarAlert'
 import { folderSelectTheme as selectFolderTheme } from '../common/reactSelectThemes'
 import OutlinedIconButton from '../components/ui/OutlinedIconButton'
 import MarqueeSingleValue, { MarqueeOption } from '../components/ui/MarqueeSingleValue'
-import { SORT_OPTIONS } from '../common/constants'
+import { SORT_OPTIONS, PRIVACY_OPTIONS } from '../common/constants'
 
 const ImageFeed = ({ authenticated, searchText, cardSize, selectedImageFolder, onImageFoldersLoaded, onImageFolderChange, showFolderDropdown, uploadTick }) => {
   const [images, setImages] = React.useState([])
@@ -39,6 +39,7 @@ const ImageFeed = ({ authenticated, searchText, cardSize, selectedImageFolder, o
   const [alert, setAlert] = React.useState({ open: false })
   const [modalImage, setModalImage] = React.useState(null)
   const [sortOrder, setSortOrder] = React.useState(SORT_OPTIONS?.[0] || { value: 'newest', label: 'Newest' })
+  const [privacyFilter, setPrivacyFilter] = React.useState(PRIVACY_OPTIONS[0])
   const [randomized, setRandomized] = React.useState(false)
   const [randomizedImages, setRandomizedImages] = React.useState([])
   const [randomizeKey, setRandomizeKey] = React.useState(0)
@@ -159,17 +160,22 @@ const ImageFeed = ({ authenticated, searchText, cardSize, selectedImageFolder, o
   }, [folder.value])
 
   const displayImages = React.useMemo(() => {
-    if (folder.value === 'All Images') {
-      return filteredImages
-    }
-    return filteredImages?.filter(
-      (img) =>
-        img.path
-          .split('/')
-          .slice(0, -1)
-          .filter((f) => f !== '')[0] === folder.value,
-    )
-  }, [filteredImages, folder])
+    if (!filteredImages) return filteredImages
+
+    const folderFiltered =
+      folder.value === 'All Images'
+        ? filteredImages
+        : filteredImages.filter(
+            (img) =>
+              img.path
+                .split('/')
+                .slice(0, -1)
+                .filter((f) => f !== '')[0] === folder.value,
+          )
+
+    if (privacyFilter.value === 'all') return folderFiltered
+    return folderFiltered.filter((img) => img.info?.private === (privacyFilter.value === 'private'))
+  }, [filteredImages, folder, privacyFilter])
 
   const sortedImages = React.useMemo(() => {
     if (!displayImages) return []
@@ -195,6 +201,13 @@ const ImageFeed = ({ authenticated, searchText, cardSize, selectedImageFolder, o
 
   const handleSortChange = (option) => {
     setSortOrder(option)
+    setRandomized(false)
+    setSortKey((k) => k + 1)
+    window.scrollTo({ top: 0 })
+  }
+
+  const handlePrivacyChange = (option) => {
+    setPrivacyFilter(option)
     setRandomized(false)
     setSortKey((k) => k + 1)
     window.scrollTo({ top: 0 })
@@ -333,6 +346,20 @@ const ImageFeed = ({ authenticated, searchText, cardSize, selectedImageFolder, o
                     isSearchable={false}
                   />
                 </Box>
+                {authenticated && (
+                  <Box sx={{ minWidth: { xs: 110, sm: 130 } }}>
+                    <Select
+                      value={privacyFilter}
+                      options={PRIVACY_OPTIONS}
+                      onChange={handlePrivacyChange}
+                      styles={selectFolderTheme}
+                      menuPortalTarget={document.body}
+                      menuPosition="fixed"
+                      blurInputOnSelect
+                      isSearchable={false}
+                    />
+                  </Box>
+                )}
                 <IconButton
                   onClick={handleRandomize}
                   title="Randomize order"


### PR DESCRIPTION
- Added a new drop-down to filter the video feed to All, Public, or Private videos via client-side filtering for authenticated users (requested by #717)
- Replicated feature on the image feed via a similar (albeit slightly modified) mechanism